### PR TITLE
Possible Incorrect INT Pin assignment for BOARD_MEGA_ADK

### DIFF
--- a/Usb.h
+++ b/Usb.h
@@ -56,7 +56,7 @@ typedef MAX3421e<P6, P3>		MAX3421E;		// Black Widow
 #elif defined(BOARD_TEENSY_PLUS_PLUS)
 typedef MAX3421e<P9, P8>        MAX3421E;       // Teensy++ 2.0 & 1.0
 #elif defined(BOARD_MEGA_ADK)
-typedef MAX3421e<P53, P54>              MAX3421E;               // Arduino Mega ADK
+typedef MAX3421e<P53, P9>              MAX3421E;               // Arduino Mega ADK
 #else
 typedef MAX3421e<P10, P9>		MAX3421E;		// Official Arduinos (UNO, Duemilanove, Mega, 2560
 #endif


### PR DESCRIPTION
I am using a Seeduino ADK board (should be the same as BOARD_MEGA_ADK), but I had the "OSCOKIRQ failed to assert" error even after uncommenting the "#define BOARD_MEGA_ADK" in avrpins.h. I was eventually able to track this down to an incorrectly assigned INT pin (defined here as P54, while it should be P9) on line 59. I don't know why this pin was chosen. The Android Open Accessory Development Kit(http://developer.android.com/guide/topics/usb/adk.html) contains a package that defines MAX_INT as P9 and not P54. The only other possibility I can think of is that the Google reference board board is not 100% identical to BOARD_MEGA_ADK.

I really don't know if I'm posting this in the right place. I have never participated in an open source project. If this isn't the right place to discuss this, please point me in the right direction. :)
