### PR TITLE
Allow handling of modifier key presses

### DIFF
--- a/hidboot.cpp
+++ b/hidboot.cpp
@@ -67,48 +67,6 @@ void KeyboardReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t 
 			if (buf[j] == prevState.bInfo[i] && prevState.bInfo[i] != 1)	// if any of the keys in the previous
 				up = false;													// is found now, then it has not been
 		}																	// released
-		
-		// handle modifier keys
-		if ( (buf[0] & 0x01) > (prevState.bInfo[0] & 0x01))		// left CTRL was pressed
-			OnKeyDown (*buf, 0xe0);
-		if ( (buf[0] & 0x01) < (prevState.bInfo[0] & 0x01))		// left CTRL was release
-			OnKeyUp (*buf, 0xe0);
-			
-		if ( (buf[0] & 0x02) > (prevState.bInfo[0] & 0x02))		// left SHIFT was pressed
-			OnKeyDown (*buf, 0xe1);
-		if ( (buf[0] & 0x02) < (prevState.bInfo[0] & 0x02))		// left SHIFT was release
-			OnKeyUp (*buf, 0xe1);
-			
-		if ( (buf[0] & 0x04) > (prevState.bInfo[0] & 0x04))		// left ALT was pressed
-			OnKeyDown (*buf, 0xe2);
-		if ( (buf[0] & 0x04) < (prevState.bInfo[0] & 0x04))		// left ALT was release
-			OnKeyUp (*buf, 0xe2);
-			
-		if ( (buf[0] & 0x08) > (prevState.bInfo[0] & 0x08))		// left GUI was pressed
-			OnKeyDown (*buf, 0xe3);
-		if ( (buf[0] & 0x08) < (prevState.bInfo[0] & 0x08))		// left GUI was release
-			OnKeyUp (*buf, 0xe3);
-
-		if ( (buf[0] & 0x10) > (prevState.bInfo[0] & 0x10))		// right CTRL was pressed
-			OnKeyDown (*buf, 0xe4);
-		if ( (buf[0] & 0x10) < (prevState.bInfo[0] & 0x10))		// right CTRL was release
-			OnKeyUp (*buf, 0xe4);
-			
-		if ( (buf[0] & 0x20) > (prevState.bInfo[0] & 0x20))		// right SHIFT was pressed
-			OnKeyDown (*buf, 0xe5);
-		if ( (buf[0] & 0x20) < (prevState.bInfo[0] & 0x20))		// right SHIFT was release
-			OnKeyUp (*buf, 0xe5);
-			
-		if ( (buf[0] & 0x40) > (prevState.bInfo[0] & 0x40))		// right ALT was pressed
-			OnKeyDown (*buf, 0xe6);
-		if ( (buf[0] & 0x40) < (prevState.bInfo[0] & 0x40))		// right ALT was release
-			OnKeyUp (*buf, 0xe6);
-			
-		if ( (buf[0] & 0x80) > (prevState.bInfo[0] & 0x80))		// right GUI was pressed
-			OnKeyDown (*buf, 0xe7);
-		if ( (buf[0] & 0x80) < (prevState.bInfo[0] & 0x80))		// right GUI was release
-			OnKeyUp (*buf, 0xe7);
-
 			
 		if (down)
 		{
@@ -120,6 +78,51 @@ void KeyboardReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t 
 			OnKeyUp(prevState.bInfo[0], prevState.bInfo[i]);
 		}
 	}
+
+	// handle modifier keys
+	if ( (buf[0] & 0x01) > (prevState.bInfo[0] & 0x01))		// left CTRL was pressed
+		OnKeyDown (*buf, 0xe0);
+	if ( (buf[0] & 0x01) < (prevState.bInfo[0] & 0x01))		// left CTRL was release
+		OnKeyUp (prevState.bInfo[0], 0xe0);
+
+	if ( (buf[0] & 0x02) > (prevState.bInfo[0] & 0x02))		// left SHIFT was pressed
+		OnKeyDown (*buf, 0xe1);
+	if ( (buf[0] & 0x02) < (prevState.bInfo[0] & 0x02))		// left SHIFT was release
+		OnKeyUp (prevState.bInfo[0], 0xe1);
+		
+	if ( (buf[0] & 0x04) > (prevState.bInfo[0] & 0x04))		// left ALT was pressed
+		OnKeyDown (*buf, 0xe2);
+	if ( (buf[0] & 0x04) < (prevState.bInfo[0] & 0x04))		// left ALT was release
+		OnKeyUp (prevState.bInfo[0], 0xe2);
+		
+	if ( (buf[0] & 0x08) > (prevState.bInfo[0] & 0x08))		// left GUI was pressed
+		OnKeyDown (*buf, 0xe3);
+	if ( (buf[0] & 0x08) < (prevState.bInfo[0] & 0x08))		// left GUI was release
+		OnKeyUp (prevState.bInfo[0], 0xe3);
+
+	if ( (buf[0] & 0x10) > (prevState.bInfo[0] & 0x10))		// right CTRL was pressed
+		OnKeyDown (*buf, 0xe4);
+	if ( (buf[0] & 0x10) < (prevState.bInfo[0] & 0x10))		// right CTRL was release
+		OnKeyUp (prevState.bInfo[0], 0xe4);
+
+	if ( (buf[0] & 0x20) > (prevState.bInfo[0] & 0x20))		// right SHIFT was pressed
+		OnKeyDown (*buf, 0xe5);
+	if ( (buf[0] & 0x20) < (prevState.bInfo[0] & 0x20))		// right SHIFT was release
+		OnKeyUp (prevState.bInfo[0], 0xe5);
+		
+	if ( (buf[0] & 0x40) > (prevState.bInfo[0] & 0x40))		// right ALT was pressed
+		OnKeyDown (*buf, 0xe6);
+	if ( (buf[0] & 0x40) < (prevState.bInfo[0] & 0x40))		// right ALT was release
+		OnKeyUp (prevState.bInfo[0], 0xe6);
+		
+	if ( (buf[0] & 0x80) > (prevState.bInfo[0] & 0x80))		// right GUI was pressed
+		OnKeyDown (*buf, 0xe7);
+	if ( (buf[0] & 0x80) < (prevState.bInfo[0] & 0x80))		// right GUI was release
+		OnKeyUp (prevState.bInfo[0], 0xe7);
+
+
+
+
 	/*
 	for (uint8_t i=0; i<8; i++)
 		prevState.bInfo[i] = buf[i];


### PR DESCRIPTION
Change the boolean variables of up and down more intuitive
Added code to handle key press and release events for modifier keys.
This is useful for handling modifier key presses without other keys
being pressed, e.g., CTRL-click in windows to select multiple files.
