### PR TITLE
Make KeyboardReportParser::handleLockingKeys() virtual to override keyboard LED handling.

### DIFF
--- a/hidboot.h
+++ b/hidboot.h
@@ -159,7 +159,7 @@ public:
         virtual void Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 
 protected:
-        uint8_t HandleLockingKeys(HID* hid, uint8_t key);
+        virtual uint8_t HandleLockingKeys(HID* hid, uint8_t key);
 
         virtual void OnKeyDown(uint8_t mod, uint8_t key) {
         };


### PR DESCRIPTION
By overriding the handleLockingKeys() method one is able to use the keyboard LEDs differently - e.g. make them blink when a certain lock state is enabled.
