### PR TITLE
Event for changed control keys

### DIFF
--- a/examples/HID/USBHIDBootKbd/USBHIDBootKbd.ino
+++ b/examples/HID/USBHIDBootKbd/USBHIDBootKbd.ino
@@ -20,6 +20,8 @@ class KbdRptParser : public KeyboardReportParser
         void PrintKey(uint8_t mod, uint8_t key);
         
 protected:
+        virtual void OnControlKeysChanged(uint8_t before, uint8_t after);
+        
 	virtual void OnKeyDown	(uint8_t mod, uint8_t key);
 	virtual void OnKeyUp	(uint8_t mod, uint8_t key);
 	virtual void OnKeyPressed(uint8_t key);
@@ -52,6 +54,42 @@ void KbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
     
     if (c)
         OnKeyPressed(c);
+}
+
+void KbdRptParser::OnControlKeysChanged(uint8_t before, uint8_t after) {
+
+    MODIFIERKEYS beforeMod;
+    *((uint8_t*)&beforeMod) = before;
+
+    MODIFIERKEYS afterMod;
+    *((uint8_t*)&afterMod) = after;
+    
+    if (beforeMod.bmLeftCtrl != afterMod.bmLeftCtrl) {
+        Serial.println("LeftCtrl changed");
+    }
+    if (beforeMod.bmLeftShift != afterMod.bmLeftShift) {
+        Serial.println("LeftShift changed");
+    }
+    if (beforeMod.bmLeftAlt != afterMod.bmLeftAlt) {
+        Serial.println("LeftAlt changed");
+    }
+    if (beforeMod.bmLeftGUI != afterMod.bmLeftGUI) {
+        Serial.println("LeftGUI changed");
+    }
+
+    if (beforeMod.bmRightCtrl != afterMod.bmRightCtrl) {
+        Serial.println("RightCtrl changed");
+    }
+    if (beforeMod.bmRightShift != afterMod.bmRightShift) {
+        Serial.println("RightShift changed");
+    }
+    if (beforeMod.bmRightAlt != afterMod.bmRightAlt) {
+        Serial.println("RightAlt changed");
+    }
+    if (beforeMod.bmRightGUI != afterMod.bmRightGUI) {
+        Serial.println("RightGUI changed");
+    }
+
 }
 
 void KbdRptParser::OnKeyUp(uint8_t mod, uint8_t key)	

--- a/hidboot.cpp
+++ b/hidboot.cpp
@@ -52,6 +52,11 @@ void KeyboardReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t 
 
         //KBDINFO	*pki = (KBDINFO*)buf;
 
+	    // provide event for changed control key state
+		if (prevState.bInfo[0x00] != buf[0x00]) {
+			OnControlKeysChanged(prevState.bInfo[0x00], buf[0x00]);
+		}
+	
         for (uint8_t i = 2; i < 8; i++) {
                 bool down = false;
                 bool up = false;

--- a/hidboot.h
+++ b/hidboot.h
@@ -161,7 +161,10 @@ public:
 protected:
         virtual uint8_t HandleLockingKeys(HID* hid, uint8_t key);
 
-        virtual void OnKeyDown(uint8_t mod, uint8_t key) {
+		virtual void OnControlKeysChanged(uint8_t before, uint8_t after) {
+		};
+	
+		virtual void OnKeyDown(uint8_t mod, uint8_t key) {
         };
 
         virtual void OnKeyUp(uint8_t mod, uint8_t key) {


### PR DESCRIPTION
This is a fix for issue #51 and adds the event KeyboardReportParser::OnControlKeysChanged(before, after) which triggers, when the state of a control key changes.
