### PR TITLE
Switch to develop branch of @PlatformIO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,10 @@ env:
 
 install:
     - python -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
+    
+    # Use PlatformIO from development branch
+    # @TODO remove this line after 2.0.3 release
+    - pip install https://github.com/platformio/platformio/archive/develop.zip    
 
     #
     # Libraries from PlatformIO Library Registry:


### PR DESCRIPTION
Using latest ``develop`` branch should avoid problems with ``ConnectionError`` to PlatformIO Storage.
More details https://github.com/platformio/platformio/commit/06baa98823db446298faabe4a8dbb51820dc34fb