### PR TITLE
Fixed toggle issue

### DIFF
--- a/Usb.cpp
+++ b/Usb.cpp
@@ -234,7 +234,7 @@ uint8_t USB::InTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t *nbytesptr, ui
                 rcode = dispatchPkt(tokIN, pep->epAddr, nak_limit); //IN packet to EP-'endpoint'. Function takes care of NAKS.
                 if(rcode == hrTOGERR) {
                         // yes, we flip it wrong here so that next time it is actually correct!
-                        pep->bmRcvToggle = (regRd(rHRSL) & bmRCVTOGRD) ? 0 : 1;
+                        pep->bmRcvToggle = (regRd(rHRSL) & bmRCVTOGRD) ? 1 : 0;
                         regWr(rHCTL, (pep->bmRcvToggle) ? bmRCVTOG1 : bmRCVTOG0); //set toggle value
                         continue;
                 }


### PR DESCRIPTION
I had to fix this in order to be able to make the acm_terminal sample working when connecting to a WaveId PcProx Plus. It seems that the toggle wasn't toggled correctly.

Note that the above comment ("yes, we flip it wrong here so that next time it is actually correct!") may not be accurate now.

I also suspect that line 173 is incorrect as it mixes bmRcvToggle and bmSNDTOGRD but I haven't changed it as it seems to work like this for me, so it's probably expected?