### PR TITLE
Added support for STM32F446 Nucleo board

### DIFF
--- a/PS3USB.cpp
+++ b/PS3USB.cpp
@@ -555,7 +555,7 @@ void PS3USB::getMoveCalibration(uint8_t *data) {
                 // bmRequest = Device to host (0x80) | Class (0x20) | Interface (0x01) = 0xA1, bRequest = Get Report (0x01), Report ID (0x10), Report Type (Feature 0x03), interface (0x00), datalength, datalength, data
                 pUsb->ctrlReq(bAddress, epInfo[PS3_CONTROL_PIPE].epAddr, bmREQ_HID_IN, HID_REQUEST_GET_REPORT, 0x10, 0x03, 0x00, 49, 49, buf, NULL);
 
-                for(byte j = 0; j < 49; j++)
+                for(uint8_t j = 0; j < 49; j++)
                         data[49 * i + j] = buf[j];
         }
 }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Currently the following boards are supported by the library:
 * RedBearLab nRF51822
 * Digilent chipKIT
     * Please see: <http://www.circuitsathome.com/mcu/usb/running-usb-host-code-on-digilent-chipkit-board>.
+* STM32F4
+    * Currently the [NUCLEO-F446RE](http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF262063) is supported featuring the STM32F446. Take a look at the following example code: <https://github.com/Lauszus/Nucleo_F446RE_USBHost>.
 
 The following boards need to be activated manually in [settings.h](settings.h):
 

--- a/avrpins.h
+++ b/avrpins.h
@@ -1074,6 +1074,62 @@ MAKE_PIN(P24, Pin_nRF51822_to_Arduino(D24));
 
 #undef MAKE_PIN
 
+#elif defined(STM32F446xx)
+// NUCLEO-F446RE
+
+#define MAKE_PIN(className, port, pin) \
+class className { \
+public: \
+  static void Set() { \
+    HAL_GPIO_WritePin(port, pin, GPIO_PIN_SET); \
+  } \
+  static void Clear() { \
+    HAL_GPIO_WritePin(port, pin, GPIO_PIN_RESET); \
+  } \
+  static void SetDirRead() { \
+    static GPIO_InitTypeDef GPIO_InitStruct; \
+    GPIO_InitStruct.Pin = pin; \
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT; \
+    GPIO_InitStruct.Pull = GPIO_NOPULL; \
+    HAL_GPIO_Init(port, &GPIO_InitStruct); \
+  } \
+  static void SetDirWrite() { \
+    static GPIO_InitTypeDef GPIO_InitStruct; \
+    GPIO_InitStruct.Pin = pin; \
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP; \
+    GPIO_InitStruct.Pull = GPIO_NOPULL; \
+    GPIO_InitStruct.Speed = GPIO_SPEED_HIGH; \
+    HAL_GPIO_Init(port, &GPIO_InitStruct); \
+  } \
+  static GPIO_PinState IsSet() { \
+    return HAL_GPIO_ReadPin(port, pin); \
+  } \
+};
+
+MAKE_PIN(P0, GPIOA, GPIO_PIN_3); // D0
+MAKE_PIN(P1, GPIOA, GPIO_PIN_2); // D1
+MAKE_PIN(P2, GPIOA, GPIO_PIN_10); // D2
+MAKE_PIN(P3, GPIOB, GPIO_PIN_3); // D3
+MAKE_PIN(P4, GPIOB, GPIO_PIN_5); // D4
+MAKE_PIN(P5, GPIOB, GPIO_PIN_4); // D5
+MAKE_PIN(P6, GPIOB, GPIO_PIN_10); // D6
+MAKE_PIN(P7, GPIOA, GPIO_PIN_8); // D7
+MAKE_PIN(P8, GPIOA, GPIO_PIN_9); // D8
+MAKE_PIN(P9, GPIOC, GPIO_PIN_7); // D9
+MAKE_PIN(P10, GPIOB, GPIO_PIN_6); // D10
+MAKE_PIN(P11, GPIOA, GPIO_PIN_7); // D11
+MAKE_PIN(P12, GPIOA, GPIO_PIN_6); // D12
+MAKE_PIN(P13, GPIOA, GPIO_PIN_5); // D13
+
+MAKE_PIN(P14, GPIOA, GPIO_PIN_0); // A0
+MAKE_PIN(P15, GPIOA, GPIO_PIN_1); // A1
+MAKE_PIN(P16, GPIOA, GPIO_PIN_4); // A2
+MAKE_PIN(P17, GPIOB, GPIO_PIN_0); // A3
+MAKE_PIN(P18, GPIOC, GPIO_PIN_1); // A4
+MAKE_PIN(P19, GPIOC, GPIO_PIN_0); // A5
+
+#undef MAKE_PIN
+
 #else
 #error "Please define board in avrpins.h"
 

--- a/max_LCD.cpp
+++ b/max_LCD.cpp
@@ -37,7 +37,7 @@ e-mail   :  support@circuitsathome.com
                             sendbyte(a);    \
                         }
 
-static byte lcdPins; //copy of LCD pins
+static uint8_t lcdPins; //copy of LCD pins
 
 Max_LCD::Max_LCD(USB *pusb) : pUsb(pusb) {
         lcdPins = 0;

--- a/settings.h
+++ b/settings.h
@@ -142,4 +142,9 @@ e-mail   :  support@circuitsathome.com
 #include <../../../../hardware/pic32/libraries/SPI/SPI.h> // Hack to use the SPI library
 #endif
 
+#ifdef STM32F4
+#include "stm32f4xx_hal.h"
+extern SPI_HandleTypeDef SPI_Handle; // Needed to be declared in your main.cpp
+#endif
+
 #endif /* SETTINGS_H */


### PR DESCRIPTION
Should be trivial to add support for other STM32 microcontrollers in the future.

Take a look at the following example: https://github.com/Lauszus/Nucleo_F446RE_USBHost