### PR TITLE
Compatibility with Arduino's core HID / Mouse / Keyboard libraries

### DIFF
--- a/BTD.h
+++ b/BTD.h
@@ -19,7 +19,7 @@
 #define _btd_h_
 
 #include "Usb.h"
-#include "hid.h"
+#include "usbhid.h"
 
 //PID and VID of the Sony PS3 devices
 #define PS3_VID                 0x054C  // Sony Corporation

--- a/BTHID.cpp
+++ b/BTHID.cpp
@@ -22,7 +22,7 @@
 
 BTHID::BTHID(BTD *p, bool pair, const char *pin) :
 BluetoothService(p), // Pointer to USB class instance - mandatory
-protocolMode(HID_BOOT_PROTOCOL) {
+protocolMode(USB_HID_BOOT_PROTOCOL) {
         for(uint8_t i = 0; i < NUM_PARSERS; i++)
                 pRptParser[i] = NULL;
 
@@ -192,12 +192,12 @@ void BTHID::ACLData(uint8_t* l2capinbuf) {
                                 switch(l2capinbuf[9]) {
                                         case 0x01: // Keyboard or Joystick events
                                                 if(pRptParser[KEYBOARD_PARSER_ID])
-                                                        pRptParser[KEYBOARD_PARSER_ID]->Parse(reinterpret_cast<HID *>(this), 0, (uint8_t)(length - 2), &l2capinbuf[10]); // Use reinterpret_cast again to extract the instance
+                                                        pRptParser[KEYBOARD_PARSER_ID]->Parse(reinterpret_cast<USBHID *>(this), 0, (uint8_t)(length - 2), &l2capinbuf[10]); // Use reinterpret_cast again to extract the instance
                                                 break;
 
                                         case 0x02: // Mouse events
                                                 if(pRptParser[MOUSE_PARSER_ID])
-                                                        pRptParser[MOUSE_PARSER_ID]->Parse(reinterpret_cast<HID *>(this), 0, (uint8_t)(length - 2), &l2capinbuf[10]); // Use reinterpret_cast again to extract the instance
+                                                        pRptParser[MOUSE_PARSER_ID]->Parse(reinterpret_cast<USBHID *>(this), 0, (uint8_t)(length - 2), &l2capinbuf[10]); // Use reinterpret_cast again to extract the instance
                                                 break;
 #ifdef EXTRADEBUG
                                         default:
@@ -380,11 +380,11 @@ void BTHID::setProtocol() {
         Notify(PSTR("\r\nSet protocol mode: "), 0x80);
         D_PrintHex<uint8_t > (protocolMode, 0x80);
 #endif
-        if (protocolMode != HID_BOOT_PROTOCOL && protocolMode != HID_RPT_PROTOCOL) {
+        if (protocolMode != USB_HID_BOOT_PROTOCOL && protocolMode != HID_RPT_PROTOCOL) {
 #ifdef DEBUG_USB_HOST
                 Notify(PSTR("\r\nNot a valid protocol mode. Using Boot protocol instead."), 0x80);
 #endif
-                protocolMode = HID_BOOT_PROTOCOL; // Use Boot Protocol by default
+                protocolMode = USB_HID_BOOT_PROTOCOL; // Use Boot Protocol by default
         }
         uint8_t command = 0x70 | protocolMode; // Set Protocol, see Bluetooth HID specs page 33
         pBtd->L2CAP_Command(hci_handle, &command, 1, control_scid[0], control_scid[1]);

--- a/BTHID.h
+++ b/BTHID.h
@@ -67,7 +67,7 @@ public:
 
         /**
          * Set HID protocol mode.
-         * @param mode HID protocol to use. Either HID_BOOT_PROTOCOL or HID_RPT_PROTOCOL.
+         * @param mode HID protocol to use. Either USB_HID_BOOT_PROTOCOL or HID_RPT_PROTOCOL.
          */
         void setProtocolMode(uint8_t mode) {
                 protocolMode = mode;

--- a/PS3USB.h
+++ b/PS3USB.h
@@ -19,7 +19,7 @@
 #define _ps3usb_h_
 
 #include "Usb.h"
-#include "hid.h"
+#include "usbhid.h"
 #include "PS3Enums.h"
 
 /* PS3 data taken from descriptors */

--- a/PS4USB.h
+++ b/PS4USB.h
@@ -64,7 +64,7 @@ protected:
          * @param len       The length of the incoming data.
          * @param buf       Pointer to the data buffer.
          */
-        virtual void ParseHIDData(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
+        virtual void ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
                 if (HIDUniversal::VID == PS4_VID && HIDUniversal::PID == PS4_PID)
                         PS4Parser::Parse(len, buf);
         };

--- a/PSBuzz.cpp
+++ b/PSBuzz.cpp
@@ -20,7 +20,7 @@
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS Buzz Controllers
 
-void PSBuzz::ParseHIDData(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
+void PSBuzz::ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
         if (HIDUniversal::VID == PSBUZZ_VID && HIDUniversal::PID == PSBUZZ_PID && len > 2 && buf) {
 #ifdef PRINTREPORT
                 Notify(PSTR("\r\n"), 0x80);

--- a/PSBuzz.h
+++ b/PSBuzz.h
@@ -143,7 +143,7 @@ protected:
          * @param len       The length of the incoming data.
          * @param buf       Pointer to the data buffer.
          */
-        void ParseHIDData(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+        void ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 
         /**
          * Called when a device is successfully initialized.

--- a/XBOXOLD.h
+++ b/XBOXOLD.h
@@ -19,7 +19,7 @@
 #define _xboxold_h_
 
 #include "Usb.h"
-#include "hid.h"
+#include "usbhid.h"
 #include "controllerEnums.h"
 
 /* Data Xbox taken from descriptors */

--- a/XBOXUSB.h
+++ b/XBOXUSB.h
@@ -19,7 +19,7 @@
 #define _xboxusb_h_
 
 #include "Usb.h"
-#include "hid.h"
+#include "usbhid.h"
 #include "xboxEnums.h"
 
 /* Data Xbox 360 taken from descriptors */

--- a/examples/Bluetooth/BTHID/BTHID.ino
+++ b/examples/Bluetooth/BTHID/BTHID.ino
@@ -45,7 +45,7 @@ void setup() {
 
   // If "Boot Protocol Mode" does not work, then try "Report Protocol Mode"
   // If that does not work either, then uncomment PRINTREPORT in BTHID.cpp to see the raw report
-  bthid.setProtocolMode(HID_BOOT_PROTOCOL); // Boot Protocol Mode
+  bthid.setProtocolMode(USB_HID_BOOT_PROTOCOL); // Boot Protocol Mode
   //bthid.setProtocolMode(HID_RPT_PROTOCOL); // Report Protocol Mode
 
   Serial.print(F("\r\nHID Bluetooth Library Started"));

--- a/examples/Bluetooth/BTHID/KeyboardParser.h
+++ b/examples/Bluetooth/BTHID/KeyboardParser.h
@@ -3,7 +3,7 @@
 
 class KbdRptParser : public KeyboardReportParser {
   protected:
-    virtual uint8_t HandleLockingKeys(HID *hid, uint8_t key);
+    virtual uint8_t HandleLockingKeys(USBHID *hid, uint8_t key);
     virtual void OnControlKeysChanged(uint8_t before, uint8_t after);
     virtual void OnKeyDown(uint8_t mod, uint8_t key);
     virtual void OnKeyUp(uint8_t mod, uint8_t key);
@@ -13,7 +13,7 @@ class KbdRptParser : public KeyboardReportParser {
     void PrintKey(uint8_t mod, uint8_t key);
 };
 
-uint8_t KbdRptParser::HandleLockingKeys(HID *hid, uint8_t key) {
+uint8_t KbdRptParser::HandleLockingKeys(USBHID *hid, uint8_t key) {
   uint8_t old_keys = kbdLockingKeys.bLeds;
 
   switch (key) {

--- a/examples/HID/USBHIDBootKbd/USBHIDBootKbd.ino
+++ b/examples/HID/USBHIDBootKbd/USBHIDBootKbd.ino
@@ -98,7 +98,7 @@ void KbdRptParser::OnKeyPressed(uint8_t key)
 
 USB     Usb;
 //USBHub     Hub(&Usb);
-HIDBoot<HID_PROTOCOL_KEYBOARD>    HidKeyboard(&Usb);
+HIDBoot<USB_HID_PROTOCOL_KEYBOARD>    HidKeyboard(&Usb);
 
 uint32_t next_time;
 

--- a/examples/HID/USBHIDBootKbdAndMouse/USBHIDBootKbdAndMouse.ino
+++ b/examples/HID/USBHIDBootKbdAndMouse/USBHIDBootKbdAndMouse.ino
@@ -141,9 +141,9 @@ void KbdRptParser::OnKeyPressed(uint8_t key)
 USB     Usb;
 USBHub     Hub(&Usb);
 
-HIDBoot < HID_PROTOCOL_KEYBOARD | HID_PROTOCOL_MOUSE > HidComposite(&Usb);
-HIDBoot<HID_PROTOCOL_KEYBOARD>    HidKeyboard(&Usb);
-HIDBoot<HID_PROTOCOL_MOUSE>    HidMouse(&Usb);
+HIDBoot < USB_HID_PROTOCOL_KEYBOARD | USB_HID_PROTOCOL_MOUSE > HidComposite(&Usb);
+HIDBoot<USB_HID_PROTOCOL_KEYBOARD>    HidKeyboard(&Usb);
+HIDBoot<USB_HID_PROTOCOL_MOUSE>    HidMouse(&Usb);
 
 //uint32_t next_time;
 

--- a/examples/HID/USBHIDBootMouse/USBHIDBootMouse.ino
+++ b/examples/HID/USBHIDBootMouse/USBHIDBootMouse.ino
@@ -52,7 +52,7 @@ void MouseRptParser::OnMiddleButtonDown	(MOUSEINFO *mi)
 
 USB     Usb;
 USBHub     Hub(&Usb);
-HIDBoot<HID_PROTOCOL_MOUSE>    HidMouse(&Usb);
+HIDBoot<USB_HID_PROTOCOL_MOUSE>    HidMouse(&Usb);
 
 uint32_t next_time;
 

--- a/examples/HID/USBHIDJoystick/USBHIDJoystick.ino
+++ b/examples/HID/USBHIDJoystick/USBHIDJoystick.ino
@@ -1,4 +1,4 @@
-#include <hid.h>
+#include <usbhid.h>
 #include <hiduniversal.h>
 #include <usbhub.h>
 

--- a/examples/HID/USBHIDJoystick/hidjoystickrptparser.cpp
+++ b/examples/HID/USBHIDJoystick/hidjoystickrptparser.cpp
@@ -8,7 +8,7 @@ oldButtons(0) {
                 oldPad[i] = 0xD;
 }
 
-void JoystickReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
+void JoystickReportParser::Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
         bool match = true;
 
         // Checking if there are changes in report since the method was last called

--- a/examples/HID/USBHIDJoystick/hidjoystickrptparser.h
+++ b/examples/HID/USBHIDJoystick/hidjoystickrptparser.h
@@ -1,7 +1,7 @@
 #if !defined(__HIDJOYSTICKRPTPARSER_H__)
 #define __HIDJOYSTICKRPTPARSER_H__
 
-#include <hid.h>
+#include <usbhid.h>
 
 struct GamePadEventData {
         uint8_t X, Y, Z1, Z2, Rz;
@@ -27,7 +27,7 @@ class JoystickReportParser : public HIDReportParser {
 public:
         JoystickReportParser(JoystickEvents *evt);
 
-        virtual void Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+        virtual void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 };
 
 #endif // __HIDJOYSTICKRPTPARSER_H__

--- a/examples/HID/USBHID_desc/USBHID_desc.ino
+++ b/examples/HID/USBHID_desc/USBHID_desc.ino
@@ -1,4 +1,4 @@
-#include <hid.h>
+#include <usbhid.h>
 #include <hiduniversal.h>
 #include <hidescriptorparser.h>
 #include <usbhub.h>

--- a/examples/HID/le3dp/le3dp.ino
+++ b/examples/HID/le3dp/le3dp.ino
@@ -1,6 +1,6 @@
 /* Simplified Logitech Extreme 3D Pro Joystick Report Parser */
 
-#include <hid.h>
+#include <usbhid.h>
 #include <hiduniversal.h>
 #include <usbhub.h>
 

--- a/examples/HID/le3dp/le3dp_rptparser.cpp
+++ b/examples/HID/le3dp/le3dp_rptparser.cpp
@@ -4,7 +4,7 @@ JoystickReportParser::JoystickReportParser(JoystickEvents *evt) :
 	joyEvents(evt)
 {}
 
-void JoystickReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf)
+void JoystickReportParser::Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf)
 {
 	bool match = true;
 

--- a/examples/HID/le3dp/le3dp_rptparser.h
+++ b/examples/HID/le3dp/le3dp_rptparser.h
@@ -1,7 +1,7 @@
 #if !defined(__HIDJOYSTICKRPTPARSER_H__)
 #define __HIDJOYSTICKRPTPARSER_H__
 
-#include <hid.h>
+#include <usbhid.h>
 
 struct GamePadEventData
 {
@@ -36,7 +36,7 @@ class JoystickReportParser : public HIDReportParser
 public:
 	JoystickReportParser(JoystickEvents *evt);
 
-	virtual void Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+	virtual void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 };
 
 #endif // __HIDJOYSTICKRPTPARSER_H__

--- a/examples/HID/scale/scale.ino
+++ b/examples/HID/scale/scale.ino
@@ -1,7 +1,7 @@
 /* Digital Scale Output. Written for Stamps.com Model 510  */
 /* 5lb Digital Scale; any HID scale with Usage page 0x8d should work */
 
-#include <hid.h>
+#include <usbhid.h>
 #include <hiduniversal.h>
 #include <usbhub.h>
 

--- a/examples/HID/scale/scale_rptparser.cpp
+++ b/examples/HID/scale/scale_rptparser.cpp
@@ -24,7 +24,7 @@ ScaleReportParser::ScaleReportParser(ScaleEvents *evt) :
 	scaleEvents(evt)
 {}
 
-void ScaleReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf)
+void ScaleReportParser::Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf)
 {
 	bool match = true;
 

--- a/examples/HID/scale/scale_rptparser.h
+++ b/examples/HID/scale/scale_rptparser.h
@@ -2,7 +2,7 @@
 #define __SCALERPTPARSER_H__
 
 #include <max_LCD.h>
-#include <hid.h>
+#include <usbhid.h>
 
 /* Scale status constants */
 #define REPORT_FAULT 0x01
@@ -49,7 +49,7 @@ class ScaleReportParser : public HIDReportParser
 public:
 	ScaleReportParser(ScaleEvents *evt);
 
-	virtual void Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+	virtual void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 };
 
 #endif // __SCALERPTPARSER_H__

--- a/examples/adk/adk_barcode/adk_barcode.ino
+++ b/examples/adk/adk_barcode/adk_barcode.ino
@@ -14,7 +14,7 @@
 USB Usb;
 USBHub Hub1(&Usb);
 USBHub Hub2(&Usb);
-HIDBoot<HID_PROTOCOL_KEYBOARD> HidKeyboard(&Usb);
+HIDBoot<USB_HID_PROTOCOL_KEYBOARD> HidKeyboard(&Usb);
 
 ADK adk(&Usb,"Circuits@Home, ltd.",
             "USB Host Shield",

--- a/hidboot.cpp
+++ b/hidboot.cpp
@@ -16,7 +16,7 @@ e-mail   :  support@circuitsathome.com
  */
 #include "hidboot.h"
 
-void MouseReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
+void MouseReportParser::Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
         MOUSEINFO *pmi = (MOUSEINFO*)buf;
         // Future:
         // bool event;
@@ -124,7 +124,7 @@ void MouseReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *bu
 
 };
 
-void KeyboardReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
+void KeyboardReportParser::Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
         // On error - return
         if (buf[2] == 1)
                 return;

--- a/hidescriptorparser.cpp
+++ b/hidescriptorparser.cpp
@@ -1578,7 +1578,7 @@ void ReportDescParser2::OnInputItem(uint8_t itm) {
         E_Notify(PSTR("\r\n"), 0x80);
 }
 
-void UniversalReportParser::Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
+void UniversalReportParser::Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
         ReportDescParser2 prs(len, buf);
 
         uint8_t ret = hid->GetReportDescr(0, &prs);

--- a/hidescriptorparser.h
+++ b/hidescriptorparser.h
@@ -17,7 +17,7 @@ e-mail   :  support@circuitsathome.com
 #if !defined(__HIDDESCRIPTORPARSER_H__)
 #define __HIDDESCRIPTORPARSER_H__
 
-#include "hid.h"
+#include "usbhid.h"
 
 class ReportDescParserBase : public USBReadParser {
 public:
@@ -170,7 +170,7 @@ public:
 class UniversalReportParser : public HIDReportParser {
 public:
         // Method should be defined here if virtual.
-        virtual void Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+        virtual void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 };
 
 #endif // __HIDDESCRIPTORPARSER_H__

--- a/hiduniversal.cpp
+++ b/hiduniversal.cpp
@@ -18,7 +18,7 @@ e-mail   :  support@circuitsathome.com
 #include "hiduniversal.h"
 
 HIDUniversal::HIDUniversal(USB *p) :
-HID(p),
+USBHID(p),
 qNextPollTime(0),
 pollInterval(0),
 bPollEnable(false),

--- a/hiduniversal.h
+++ b/hiduniversal.h
@@ -18,10 +18,10 @@ e-mail   :  support@circuitsathome.com
 #if !defined(__HIDUNIVERSAL_H__)
 #define __HIDUNIVERSAL_H__
 
-#include "hid.h"
+#include "usbhid.h"
 //#include "hidescriptorparser.h"
 
-class HIDUniversal : public HID {
+class HIDUniversal : public USBHID {
 
         struct ReportParser {
                 uint8_t rptId;
@@ -75,7 +75,7 @@ protected:
                 return 0;
         };
 
-        virtual void ParseHIDData(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
+        virtual void ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
                 return;
         };
 

--- a/usbhid.cpp
+++ b/usbhid.cpp
@@ -15,12 +15,12 @@ Web      :  http://www.circuitsathome.com
 e-mail   :  support@circuitsathome.com
  */
 
-#include "hid.h"
+#include "usbhid.h"
 
 //get HID report descriptor
 
 /* WRONG! Endpoint is _ALWAYS_ ZERO for HID! We want the _INTERFACE_ value here!
-uint8_t HID::GetReportDescr(uint8_t ep, USBReadParser *parser) {
+uint8_t USBHID::GetReportDescr(uint8_t ep, USBReadParser *parser) {
         const uint8_t constBufLen = 64;
         uint8_t buf[constBufLen];
 
@@ -31,7 +31,7 @@ uint8_t HID::GetReportDescr(uint8_t ep, USBReadParser *parser) {
         return rcode;
 }
  */
-uint8_t HID::GetReportDescr(uint16_t wIndex, USBReadParser *parser) {
+uint8_t USBHID::GetReportDescr(uint16_t wIndex, USBReadParser *parser) {
         const uint8_t constBufLen = 64;
         uint8_t buf[constBufLen];
 
@@ -42,36 +42,36 @@ uint8_t HID::GetReportDescr(uint16_t wIndex, USBReadParser *parser) {
         return rcode;
 }
 
-//uint8_t HID::getHidDescr( uint8_t ep, uint16_t nbytes, uint8_t* dataptr )
+//uint8_t USBHID::getHidDescr( uint8_t ep, uint16_t nbytes, uint8_t* dataptr )
 //{
 //    return( pUsb->ctrlReq( bAddress, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, 0x00, HID_DESCRIPTOR_HID, 0x0000, nbytes, dataptr ));
 //}
 
-uint8_t HID::SetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr) {
+uint8_t USBHID::SetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr) {
         return ( pUsb->ctrlReq(bAddress, ep, bmREQ_HID_OUT, HID_REQUEST_SET_REPORT, report_id, report_type, iface, nbytes, nbytes, dataptr, NULL));
 }
 
-uint8_t HID::GetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr) {
+uint8_t USBHID::GetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr) {
         return ( pUsb->ctrlReq(bAddress, ep, bmREQ_HID_IN, HID_REQUEST_GET_REPORT, report_id, report_type, iface, nbytes, nbytes, dataptr, NULL));
 }
 
-uint8_t HID::GetIdle(uint8_t iface, uint8_t reportID, uint8_t* dataptr) {
+uint8_t USBHID::GetIdle(uint8_t iface, uint8_t reportID, uint8_t* dataptr) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_HID_IN, HID_REQUEST_GET_IDLE, reportID, 0, iface, 0x0001, 0x0001, dataptr, NULL));
 }
 
-uint8_t HID::SetIdle(uint8_t iface, uint8_t reportID, uint8_t duration) {
+uint8_t USBHID::SetIdle(uint8_t iface, uint8_t reportID, uint8_t duration) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_HID_OUT, HID_REQUEST_SET_IDLE, reportID, duration, iface, 0x0000, 0x0000, NULL, NULL));
 }
 
-uint8_t HID::SetProtocol(uint8_t iface, uint8_t protocol) {
+uint8_t USBHID::SetProtocol(uint8_t iface, uint8_t protocol) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_HID_OUT, HID_REQUEST_SET_PROTOCOL, protocol, 0x00, iface, 0x0000, 0x0000, NULL, NULL));
 }
 
-uint8_t HID::GetProtocol(uint8_t iface, uint8_t* dataptr) {
+uint8_t USBHID::GetProtocol(uint8_t iface, uint8_t* dataptr) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_HID_IN, HID_REQUEST_GET_PROTOCOL, 0x00, 0x00, iface, 0x0001, 0x0001, dataptr, NULL));
 }
 
-void HID::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr) {
+void USBHID::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr) {
         Notify(PSTR("Endpoint descriptor:"), 0x80);
         Notify(PSTR("\r\nLength:\t\t"), 0x80);
         D_PrintHex<uint8_t > (ep_ptr->bLength, 0x80);
@@ -87,7 +87,7 @@ void HID::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr) {
         D_PrintHex<uint8_t > (ep_ptr->bInterval, 0x80);
 }
 
-void HID::PrintHidDescriptor(const USB_HID_DESCRIPTOR *pDesc) {
+void USBHID::PrintHidDescriptor(const USB_HID_DESCRIPTOR *pDesc) {
         Notify(PSTR("\r\n\r\nHID Descriptor:\r\n"), 0x80);
         Notify(PSTR("bDescLength:\t\t"), 0x80);
         D_PrintHex<uint8_t > (pDesc->bLength, 0x80);

--- a/usbhid.h
+++ b/usbhid.h
@@ -14,8 +14,8 @@ Circuits At Home, LTD
 Web      :  http://www.circuitsathome.com
 e-mail   :  support@circuitsathome.com
  */
-#if !defined(__HID_H__)
-#define __HID_H__
+#if !defined(__USBHID_H__)
+#define __USBHID_H__
 
 #include "Usb.h"
 #include "hidusagestr.h"
@@ -79,7 +79,7 @@ e-mail   :  support@circuitsathome.com
 #define HID_DESRIPTOR_PHY                       0x23
 
 /* Protocol Selection */
-#define HID_BOOT_PROTOCOL                       0x00
+#define USB_HID_BOOT_PROTOCOL                   0x00
 #define HID_RPT_PROTOCOL                        0x01
 
 /* HID Interface Class Code */
@@ -89,9 +89,9 @@ e-mail   :  support@circuitsathome.com
 #define HID_BOOT_INTF_SUBCLASS                  0x01
 
 /* HID Interface Class Protocol Codes */
-#define HID_PROTOCOL_NONE                       0x00
-#define HID_PROTOCOL_KEYBOARD                   0x01
-#define HID_PROTOCOL_MOUSE                      0x02
+#define USB_HID_PROTOCOL_NONE                       0x00
+#define USB_HID_PROTOCOL_KEYBOARD                   0x01
+#define USB_HID_PROTOCOL_MOUSE                      0x02
 
 #define HID_ITEM_TYPE_MAIN                      0
 #define HID_ITEM_TYPE_GLOBAL                    1
@@ -133,14 +133,14 @@ struct MainItemIOFeature {
         uint8_t bmIsVolatileOrNonVolatile : 1;
 };
 
-class HID;
+class USBHID;
 
 class HIDReportParser {
 public:
-        virtual void Parse(HID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) = 0;
+        virtual void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) = 0;
 };
 
-class HID : public USBDeviceConfig, public UsbConfigXtracter {
+class USBHID : public USBDeviceConfig, public UsbConfigXtracter {
 protected:
         USB *pUsb; // USB class instance pointer
         uint8_t bAddress; // address
@@ -162,7 +162,7 @@ protected:
 
 public:
 
-        HID(USB *pusb) : pUsb(pusb) {
+        USBHID(USB *pusb) : pUsb(pusb) {
         };
 
         const USB* GetUsb() {
@@ -185,4 +185,4 @@ public:
         uint8_t SetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr);
 };
 
-#endif // __HID_H__
+#endif // __USBHID_H__


### PR DESCRIPTION
The following collisions have been resolved:

hid.h -> usbhid.h
hid.cpp -> usbhid.cpp
HID -> USBHID
HID_BOOT_PROTOCOL -> USB_HID_BOOT_PROTOCOL
HID_PROTOCOL_NONE -> USB_HID_PROTOCOL_NONE
HID_PROTOCOL_KEYBOARD -> USB_HID_PROTOCOL_KEYBOARD
HID_PROTOCOL_MOUSE -> USB_HID_PROTOCOL_MOUSE

As a result, it's possible to use the library together with Arduino's bundled HID / Mouse / Keyboard libraries (Leonardo, Micro, or Due).

https://www.arduino.cc/en/Reference/MouseKeyboard