### PR TITLE
Have PS3.printStatusString() print to a new line.

### DIFF
--- a/PS3BT.cpp
+++ b/PS3BT.cpp
@@ -150,7 +150,7 @@ String PS3BT::getTemperature() {
 
                 return output;
         } else
-                return "Error";
+                return "\r\nError";
 }
 
 bool PS3BT::getStatus(StatusEnum c) {
@@ -158,9 +158,9 @@ bool PS3BT::getStatus(StatusEnum c) {
 }
 
 void PS3BT::printStatusString() {
-        char statusOutput[100]; // Max string length plus null character
+        char statusOutput[102]; // Max string length plus null character
         if(PS3Connected || PS3NavigationConnected) {
-                strcpy_P(statusOutput, PSTR("\nConnectionStatus: "));
+                strcpy_P(statusOutput, PSTR("\r\nConnectionStatus: "));
 
                 if(getStatus(Plugged)) strcat_P(statusOutput, PSTR("Plugged"));
                 else if(getStatus(Unplugged)) strcat_P(statusOutput, PSTR("Unplugged"));
@@ -185,7 +185,7 @@ void PS3BT::printStatusString() {
                 else if(getStatus(Bluetooth)) strcat_P(statusOutput, PSTR("Bluetooth - Rumble is off"));
                 else strcat_P(statusOutput, PSTR("Error"));
         } else if(PS3MoveConnected) {
-                strcpy_P(statusOutput, PSTR("PowerRating: "));
+                strcpy_P(statusOutput, PSTR("\r\nPowerRating: "));
 
                 if(getStatus(MoveCharging)) strcat_P(statusOutput, PSTR("Charging"));
                 else if(getStatus(MoveNotCharging)) strcat_P(statusOutput, PSTR("Not Charging"));
@@ -196,7 +196,7 @@ void PS3BT::printStatusString() {
                 else if(getStatus(MoveFull)) strcat_P(statusOutput, PSTR("Full"));
                 else strcat_P(statusOutput, PSTR("Error"));
         } else
-                strcpy_P(statusOutput, PSTR("Error"));
+                strcpy_P(statusOutput, PSTR("\r\nError"));
 
         USB_HOST_SERIAL.write(statusOutput);
 }

--- a/PS3BT.cpp
+++ b/PS3BT.cpp
@@ -150,7 +150,7 @@ String PS3BT::getTemperature() {
 
                 return output;
         } else
-                return "\r\nError";
+                return "Error";
 }
 
 bool PS3BT::getStatus(StatusEnum c) {

--- a/PS3BT.cpp
+++ b/PS3BT.cpp
@@ -160,7 +160,7 @@ bool PS3BT::getStatus(StatusEnum c) {
 void PS3BT::printStatusString() {
         char statusOutput[100]; // Max string length plus null character
         if(PS3Connected || PS3NavigationConnected) {
-                strcpy_P(statusOutput, PSTR("ConnectionStatus: "));
+                strcpy_P(statusOutput, PSTR("\nConnectionStatus: "));
 
                 if(getStatus(Plugged)) strcat_P(statusOutput, PSTR("Plugged"));
                 else if(getStatus(Unplugged)) strcat_P(statusOutput, PSTR("Unplugged"));

--- a/PS3USB.cpp
+++ b/PS3USB.cpp
@@ -364,7 +364,7 @@ bool PS3USB::getStatus(StatusEnum c) {
 void PS3USB::printStatusString() {
         char statusOutput[100]; // Max string length plus null character
         if(PS3Connected || PS3NavigationConnected) {
-                strcpy_P(statusOutput, PSTR("ConnectionStatus: "));
+                strcpy_P(statusOutput, PSTR("\nConnectionStatus: "));
 
                 if(getStatus(Plugged)) strcat_P(statusOutput, PSTR("Plugged"));
                 else if(getStatus(Unplugged)) strcat_P(statusOutput, PSTR("Unplugged"));

--- a/PS3USB.cpp
+++ b/PS3USB.cpp
@@ -362,9 +362,9 @@ bool PS3USB::getStatus(StatusEnum c) {
 }
 
 void PS3USB::printStatusString() {
-        char statusOutput[100]; // Max string length plus null character
+        char statusOutput[102]; // Max string length plus null character
         if(PS3Connected || PS3NavigationConnected) {
-                strcpy_P(statusOutput, PSTR("\nConnectionStatus: "));
+                strcpy_P(statusOutput, PSTR("\r\nConnectionStatus: "));
 
                 if(getStatus(Plugged)) strcat_P(statusOutput, PSTR("Plugged"));
                 else if(getStatus(Unplugged)) strcat_P(statusOutput, PSTR("Unplugged"));
@@ -389,7 +389,7 @@ void PS3USB::printStatusString() {
                 else if(getStatus(Bluetooth)) strcat_P(statusOutput, PSTR("Bluetooth - Rumble is off"));
                 else strcat_P(statusOutput, PSTR("Error"));
         } else
-                strcpy_P(statusOutput, PSTR("Error"));
+                strcpy_P(statusOutput, PSTR("\r\nError"));
 
         USB_HOST_SERIAL.write(statusOutput);
 }


### PR DESCRIPTION
Have PS3.printStatusString() print to a new line each time it is called, making serial output look much nicer if called multiple times.