### PR TITLE
Updated hub_demo to include string descriptors

### DIFF
--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -293,7 +293,7 @@ uint8_t getstrdescr( uint8_t addr, uint8_t idx )
     Serial.print("Error retrieving LangID table ");
     return ( rcode );
   }
-  langid = makeWord(buf[3], buf[2]);
+  langid = (buf[3] << 8) | buf[2];
   rcode = Usb.getStrDescr( addr, 0, 1, idx, langid, buf );
   if ( rcode ) {
     Serial.print("Error retrieving string length ");
@@ -418,10 +418,4 @@ void printProgStr(const char* str)
   if (!str) return;
   while ((c = pgm_read_byte(str++)))
     Serial.print(c);
-}
-
-/* Create a word from 2 bytes */
-uint16_t makeWord( uint8_t h, uint8_t l )
-{
-  return (h << 8) | l ;
 }

--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -93,7 +93,6 @@ void PrintAllDescriptors(UsbDevice *pdev)
   print_hex(pdev->address.devAddress, 8);
   Serial.println("\r\n--");
   getallstrdescr(pdev->address.devAddress);
-  //Serial.print("\r\n");
   PrintDescriptors( pdev->address.devAddress );
 }
 

--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -74,7 +74,7 @@ void PrintDescriptors(uint8_t addr)
   }
   Serial.print("\r\n");
 
-  for (int i = 0; i < num_conf; i++) {
+  for (uint8_t i = 0; i < num_conf; i++) {
     rcode = getconfdescr( addr, i );                 // get configuration descriptor
     if ( rcode ) {
       printProgStr(Gen_Error_str);
@@ -201,7 +201,7 @@ uint8_t getconfdescr( uint8_t addr, uint8_t conf )
   uint8_t rcode;
   uint8_t descr_length;
   uint8_t descr_type;
-  unsigned int total_length;
+  uint16_t total_length;
   rcode = Usb.getConfDescr( addr, 0, 4, conf, buf );  //get total length
   LOBYTE( total_length ) = buf[ 2 ];
   HIBYTE( total_length ) = buf[ 3 ];
@@ -275,13 +275,13 @@ uint8_t getallstrdescr(uint8_t addr)
 }
 
 //  function to get single string description
-unsigned int getstrdescr( unsigned int addr, uint8_t idx )
+uint8_t getstrdescr( uint8_t addr, uint8_t idx )
 {
   uint8_t buf[ 256 ];
-  unsigned int rcode;
+  uint8_t rcode;
   uint8_t length;
   uint8_t i;
-  unsigned short langid;
+  uint16_t langid;
   rcode = Usb.getStrDescr( addr, 0, 1, 0, 0, buf );  //get language table length
   if ( rcode ) {
     Serial.println("Error retrieving LangID table length");
@@ -293,7 +293,7 @@ unsigned int getstrdescr( unsigned int addr, uint8_t idx )
     Serial.print("Error retrieving LangID table ");
     return ( rcode );
   }
-  langid = word(buf[3], buf[2]);
+  langid = makeWord(buf[3], buf[2]);
   rcode = Usb.getStrDescr( addr, 0, 1, idx, langid, buf );
   if ( rcode ) {
     Serial.print("Error retrieving string length ");
@@ -411,7 +411,6 @@ void printunkdescr( uint8_t* descr_ptr )
   }
 }
 
-
 /* Print a string from Program Memory directly to save RAM */
 void printProgStr(const char* str)
 {
@@ -419,4 +418,10 @@ void printProgStr(const char* str)
   if (!str) return;
   while ((c = pgm_read_byte(str++)))
     Serial.print(c);
+}
+
+/* Create a word from 2 bytes */
+uint16_t makeWord( uint8_t h, uint8_t l )
+{
+  return (h << 8) | l ;
 }

--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -60,14 +60,14 @@ void setup()
   next_time = millis() + 10000;
 }
 
-byte getdevdescr( byte addr, byte &num_conf );
+uint8_t getdevdescr( uint8_t addr, uint8_t &num_conf );
 
 void PrintDescriptors(uint8_t addr)
 {
   uint8_t rcode = 0;
-  byte num_conf = 0;
+  uint8_t num_conf = 0;
 
-  rcode = getdevdescr( (byte)addr, num_conf );
+  rcode = getdevdescr( (uint8_t)addr, num_conf );
   if ( rcode )
   {
     printProgStr(Gen_Error_str);
@@ -112,11 +112,11 @@ void loop()
   }
 }
 
-byte getdevdescr( byte addr, byte &num_conf )
+uint8_t getdevdescr( uint8_t addr, uint8_t &num_conf )
 {
   USB_DEVICE_DESCRIPTOR buf;
-  byte rcode;
-  rcode = Usb.getDevDescr( addr, 0, 0x12, ( uint8_t *)&buf );
+  uint8_t rcode;
+  rcode = Usb.getDevDescr( addr, 0, DEV_DESCR_LEN, ( uint8_t *)&buf );
   if ( rcode ) {
     return ( rcode );
   }
@@ -199,13 +199,13 @@ void printhubdescr(uint8_t *descrptr, uint8_t addr)
   //    PrintHubPortStatus(&Usb, addr, i, 1);
 }
 
-byte getconfdescr( byte addr, byte conf )
+uint8_t getconfdescr( uint8_t addr, uint8_t conf )
 {
   uint8_t buf[ BUFSIZE ];
   uint8_t* buf_ptr = buf;
-  byte rcode;
-  byte descr_length;
-  byte descr_type;
+  uint8_t rcode;
+  uint8_t descr_length;
+  uint8_t descr_type;
   unsigned int total_length;
   rcode = Usb.getConfDescr( addr, 0, 4, conf, buf );  //get total length
   LOBYTE( total_length ) = buf[ 2 ];
@@ -241,37 +241,37 @@ byte getconfdescr( byte addr, byte conf )
 }
 
 // function to get all string descriptors
-byte getallstrdescr(uint8_t addr)
-{ 
-  byte rcode;
+uint8_t getallstrdescr(uint8_t addr)
+{
+  uint8_t rcode;
   Usb.Task();
-  if( Usb.getUsbTaskState() >= 0x80 ) {  // state configuring or higher
-    USB_DEVICE_DESCRIPTOR buf; 
-    rcode = Usb.getDevDescr( addr, 0, 0x12, ( uint8_t *)&buf );
+  if ( Usb.getUsbTaskState() >= USB_STATE_CONFIGURING ) { // state configuring or higher
+    USB_DEVICE_DESCRIPTOR buf;
+    rcode = Usb.getDevDescr( addr, 0, DEV_DESCR_LEN, ( uint8_t *)&buf );
     if ( rcode ) {
       return ( rcode );
     }
     Serial.println("String Descriptors:");
-    if( buf.iManufacturer > 0 ) {
+    if ( buf.iManufacturer > 0 ) {
       Serial.print("Manufacturer:\t\t");
       rcode = getstrdescr( addr, buf.iManufacturer );   // get manufacturer string
-      if( rcode ) {
+      if ( rcode ) {
         Serial.println( rcode, HEX );
       }
       Serial.print("\r\n");
     }
-    if( buf.iProduct > 0 ) {
+    if ( buf.iProduct > 0 ) {
       Serial.print("Product:\t\t");
       rcode = getstrdescr( addr, buf.iProduct );        // get product string
-      if( rcode ) {
+      if ( rcode ) {
         Serial.println( rcode, HEX );
       }
       Serial.print("\r\n");
     }
-    if( buf.iSerialNumber > 0 ) {
+    if ( buf.iSerialNumber > 0 ) {
       Serial.print("Serial:\t\t\t");
       rcode = getstrdescr( addr, buf.iSerialNumber );   // get serial string
-      if( rcode ) {
+      if ( rcode ) {
         Serial.println( rcode, HEX );
       }
       Serial.print("\r\n");
@@ -280,40 +280,40 @@ byte getallstrdescr(uint8_t addr)
 }
 
 //  function to get single string description
-unsigned int getstrdescr( unsigned int addr, byte idx )
+unsigned int getstrdescr( unsigned int addr, uint8_t idx )
 {
- byte buf[ 66 ];
- unsigned int rcode;
- byte length;
- byte i;
- unsigned short langid;
- rcode = Usb.getStrDescr( addr, 0, 1, 0, 0, buf );  //get language table length
- if( rcode ) {
-   Serial.println("Error retrieving LangID table length");
-   return( rcode );
- }
- length = buf[ 0 ];      //length is the first byte
- rcode = Usb.getStrDescr( addr, 0, length, 0, 0, buf );  //get language table
- if( rcode ) {
-   Serial.print("Error retrieving LangID table ");
-   return( rcode );
- }
- langid = word(buf[3], buf[2]); 
- rcode = Usb.getStrDescr( addr, 0, 1, idx, langid, buf );
- if( rcode ) {
-   Serial.print("Error retrieving string length ");
-   return( rcode );
- }
- length = buf[ 0 ];
- rcode = Usb.getStrDescr( addr, 0, length, idx, langid, buf );
- if( rcode ) {
-   Serial.print("Error retrieving string ");
-   return( rcode );
- }
- for( i = 2; i < length; i+=2 ) {
-   Serial.print((char) buf[i]);
- }
- return( rcode );
+  uint8_t buf[ 66 ];
+  unsigned int rcode;
+  uint8_t length;
+  uint8_t i;
+  unsigned short langid;
+  rcode = Usb.getStrDescr( addr, 0, 1, 0, 0, buf );  //get language table length
+  if ( rcode ) {
+    Serial.println("Error retrieving LangID table length");
+    return ( rcode );
+  }
+  length = buf[ 0 ];      //length is the first byte
+  rcode = Usb.getStrDescr( addr, 0, length, 0, 0, buf );  //get language table
+  if ( rcode ) {
+    Serial.print("Error retrieving LangID table ");
+    return ( rcode );
+  }
+  langid = word(buf[3], buf[2]);
+  rcode = Usb.getStrDescr( addr, 0, 1, idx, langid, buf );
+  if ( rcode ) {
+    Serial.print("Error retrieving string length ");
+    return ( rcode );
+  }
+  length = buf[ 0 ];
+  rcode = Usb.getStrDescr( addr, 0, length, idx, langid, buf );
+  if ( rcode ) {
+    Serial.print("Error retrieving string ");
+    return ( rcode );
+  }
+  for ( i = 2; i < length; i += 2 ) {
+    Serial.print((char) buf[i]);
+  }
+  return ( rcode );
 }
 
 /* prints hex numbers with leading zeroes */
@@ -397,8 +397,8 @@ void printepdescr( uint8_t* descr_ptr )
 /*function to print unknown descriptor */
 void printunkdescr( uint8_t* descr_ptr )
 {
-  byte length = *descr_ptr;
-  byte i;
+  uint8_t length = *descr_ptr;
+  uint8_t i;
   printProgStr(Unk_Header_str);
   printProgStr(Unk_Length_str);
   print_hex( *descr_ptr, 8 );

--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -68,18 +68,15 @@ void PrintDescriptors(uint8_t addr)
   uint8_t num_conf = 0;
 
   rcode = getdevdescr( (uint8_t)addr, num_conf );
-  if ( rcode )
-  {
+  if ( rcode ) {
     printProgStr(Gen_Error_str);
     print_hex( rcode, 8 );
   }
   Serial.print("\r\n");
 
-  for (int i = 0; i < num_conf; i++)
-  {
+  for (int i = 0; i < num_conf; i++) {
     rcode = getconfdescr( addr, i );                 // get configuration descriptor
-    if ( rcode )
-    {
+    if ( rcode ) {
       printProgStr(Gen_Error_str);
       print_hex(rcode, 8);
     }
@@ -100,10 +97,8 @@ void loop()
 {
   Usb.Task();
 
-  if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
-  {
-    if ((millis() - next_time) >= 0L)
-    {
+  if ( Usb.getUsbTaskState() == USB_STATE_RUNNING ) {
+    if ((millis() - next_time) >= 0L) {
       Usb.ForEachUsbDevice(&PrintAllDescriptors);
       Usb.ForEachUsbDevice(&PrintAllAddresses);
 
@@ -282,7 +277,7 @@ uint8_t getallstrdescr(uint8_t addr)
 //  function to get single string description
 unsigned int getstrdescr( unsigned int addr, uint8_t idx )
 {
-  uint8_t buf[ 66 ];
+  uint8_t buf[ 256 ];
   unsigned int rcode;
   uint8_t length;
   uint8_t i;
@@ -310,7 +305,7 @@ unsigned int getstrdescr( unsigned int addr, uint8_t idx )
     Serial.print("Error retrieving string ");
     return ( rcode );
   }
-  for ( i = 2; i < length; i += 2 ) {
+  for ( i = 2; i < length; i += 2 ) {   //string is UTF-16LE encoded
     Serial.print((char) buf[i]);
   }
   return ( rcode );
@@ -338,6 +333,7 @@ void print_hex(int v, int num_places)
   }
   while (--num_nibbles);
 }
+
 /* function to print configuration descriptor */
 void printconfdescr( uint8_t* descr_ptr )
 {
@@ -357,6 +353,7 @@ void printconfdescr( uint8_t* descr_ptr )
   print_hex( conf_ptr->bMaxPower, 8 );
   return;
 }
+
 /* function to print interface descriptor */
 void printintfdescr( uint8_t* descr_ptr )
 {
@@ -378,6 +375,7 @@ void printintfdescr( uint8_t* descr_ptr )
   print_hex( intf_ptr->iInterface, 8 );
   return;
 }
+
 /* function to print endpoint descriptor */
 void printepdescr( uint8_t* descr_ptr )
 {
@@ -394,6 +392,7 @@ void printepdescr( uint8_t* descr_ptr )
 
   return;
 }
+
 /*function to print unknown descriptor */
 void printunkdescr( uint8_t* descr_ptr )
 {

--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -19,7 +19,7 @@ void PrintAllAddresses(UsbDevice *pdev)
 {
   UsbDeviceAddress adr;
   adr.devAddress = pdev->address.devAddress;
-  Serial.print("\r\nAddr:");
+  Serial.print("Addr:");
   Serial.print(adr.devAddress, HEX);
   Serial.print("(");
   Serial.print(adr.bmHub, HEX);
@@ -92,6 +92,8 @@ void PrintAllDescriptors(UsbDevice *pdev)
   Serial.println("\r\n");
   print_hex(pdev->address.devAddress, 8);
   Serial.println("\r\n--");
+  getallstrdescr(pdev->address.devAddress);
+  //Serial.print("\r\n");
   PrintDescriptors( pdev->address.devAddress );
 }
 
@@ -238,6 +240,83 @@ byte getconfdescr( byte addr, byte conf )
   }//while( buf_ptr <=...
   return ( rcode );
 }
+
+// function to get all string descriptors
+byte getallstrdescr(uint8_t addr)
+{ 
+  byte rcode;
+  Usb.Task();
+  if( Usb.getUsbTaskState() >= 0x80 ) {  // state configuring or higher
+    USB_DEVICE_DESCRIPTOR buf; 
+    rcode = Usb.getDevDescr( addr, 0, 0x12, ( uint8_t *)&buf );
+    if ( rcode ) {
+      return ( rcode );
+    }
+    Serial.println("String Descriptors:");
+    if( buf.iManufacturer > 0 ) {
+      Serial.print("Manufacturer:\t\t");
+      rcode = getstrdescr( addr, buf.iManufacturer );   // get manufacturer string
+      if( rcode ) {
+        Serial.println( rcode, HEX );
+      }
+      Serial.print("\r\n");
+    }
+    if( buf.iProduct > 0 ) {
+      Serial.print("Product:\t\t");
+      rcode = getstrdescr( addr, buf.iProduct );        // get product string
+      if( rcode ) {
+        Serial.println( rcode, HEX );
+      }
+      Serial.print("\r\n");
+    }
+    if( buf.iSerialNumber > 0 ) {
+      Serial.print("Serial:\t\t\t");
+      rcode = getstrdescr( addr, buf.iSerialNumber );   // get serial string
+      if( rcode ) {
+        Serial.println( rcode, HEX );
+      }
+      Serial.print("\r\n");
+    }
+  }
+}
+
+//  function to get single string description
+unsigned int getstrdescr( unsigned int addr, byte idx )
+{
+ byte buf[ 66 ];
+ unsigned int rcode;
+ byte length;
+ byte i;
+ unsigned short langid;
+ rcode = Usb.getStrDescr( addr, 0, 1, 0, 0, buf );  //get language table length
+ if( rcode ) {
+   Serial.println("Error retrieving LangID table length");
+   return( rcode );
+ }
+ length = buf[ 0 ];      //length is the first byte
+ rcode = Usb.getStrDescr( addr, 0, length, 0, 0, buf );  //get language table
+ if( rcode ) {
+   Serial.print("Error retrieving LangID table ");
+   return( rcode );
+ }
+ langid = word(buf[3], buf[2]); 
+ rcode = Usb.getStrDescr( addr, 0, 1, idx, langid, buf );
+ if( rcode ) {
+   Serial.print("Error retrieving string length ");
+   return( rcode );
+ }
+ length = buf[ 0 ];
+ rcode = Usb.getStrDescr( addr, 0, length, idx, langid, buf );
+ if( rcode ) {
+   Serial.print("Error retrieving string ");
+   return( rcode );
+ }
+ for( i = 2; i < length; i+=2 ) {
+   Serial.print((char) buf[i]);
+ }
+ return( rcode );
+}
+
 /* prints hex numbers with leading zeroes */
 // copyright, Peter H Anderson, Baltimore, MD, Nov, '07
 // source: http://www.phanderson.com/arduino/arduino_display.html


### PR DESCRIPTION
The hub demo will now print usb string descriptors:

1] Manufacturer
2] Product Description
3] Serial Number

Also removed a new line return to make the output cleaner.

Please review.