### PR TITLE
[RedBearLab] Fix type mismatch sizeof to uint8_t

### DIFF
--- a/PS4Parser.cpp
+++ b/PS4Parser.cpp
@@ -84,7 +84,7 @@ void PS4Parser::Parse(uint8_t len, uint8_t *buf) {
 #endif
 
                 if (buf[0] == 0x01) // Check report ID
-                        memcpy(&ps4Data, buf + 1, min((uint8_t)(len - 1), sizeof(ps4Data)));
+                        memcpy(&ps4Data, buf + 1, min((uint8_t)(len - 1), MFK_CASTUINT8T sizeof(ps4Data)));
                 else if (buf[0] == 0x11) { // This report is send via Bluetooth, it has an offset of 2 compared to the USB data
                         if (len < 4) {
 #ifdef DEBUG_USB_HOST
@@ -93,7 +93,7 @@ void PS4Parser::Parse(uint8_t len, uint8_t *buf) {
 #endif
                                 return;
                         }
-                        memcpy(&ps4Data, buf + 3, min((uint8_t)(len - 3), sizeof(ps4Data)));
+                        memcpy(&ps4Data, buf + 3, min((uint8_t)(len - 3), MFK_CASTUINT8T sizeof(ps4Data)));
                 } else {
 #ifdef DEBUG_USB_HOST
                         Notify(PSTR("\r\nUnknown report id: "), 0x80);

--- a/PSBuzz.cpp
+++ b/PSBuzz.cpp
@@ -29,7 +29,7 @@ void PSBuzz::ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf
                         Notify(PSTR(" "), 0x80);
                 }
 #endif
-                memcpy(&psbuzzButtons, buf + 2, min((uint8_t)(len - 2), sizeof(psbuzzButtons)));
+                memcpy(&psbuzzButtons, buf + 2, min((uint8_t)(len - 2), MFK_CASTUINT8T sizeof(psbuzzButtons)));
 
                 if (psbuzzButtons.val != oldButtonState.val) { // Check if anything has changed
                         buttonClickState.val = psbuzzButtons.val & ~oldButtonState.val; // Update click state variable

--- a/settings.h
+++ b/settings.h
@@ -142,6 +142,7 @@ e-mail   :  support@circuitsathome.com
 #include <nrf_gpio.h>
 #include <SPI_Master.h>
 #define SPI SPI_Master
+#define MFK_CASTUINT8T (uint8_t) // RBLs return type for sizeof needs casting to uint8_t
 #endif
 #if defined(__PIC32MX__) || defined(__PIC32MZ__)
 #include <../../../../hardware/pic32/libraries/SPI/SPI.h> // Hack to use the SPI library
@@ -169,6 +170,11 @@ extern SPI_HandleTypeDef SPI_Handle; // Needed to be declared in your main.cpp
 #ifdef tokOUTHS
 #undef tokOUTHS
 #endif
+#endif
+
+// Set defaults
+#ifndef MFK_CASTUINT8T
+#define MFK_CASTUINT8T
 #endif
 
 #endif /* SETTINGS_H */


### PR DESCRIPTION
The RedbearLab compiler has a type mismatch for
STLs min() and sizeof. Thus we need to cast the
occurences of sizeof to uint8_t.