### PR TITLE
Change INT pin for ESP8266 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ Currently the following boards are supported by the library:
 * STM32F4
     * Currently the [NUCLEO-F446RE](http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF262063) is supported featuring the STM32F446. Take a look at the following example code: <https://github.com/Lauszus/Nucleo_F446RE_USBHost>.
 * ESP8266 is supported using the [ESP8266 Arduino core](https://github.com/esp8266/Arduino)
-    * Note it uses pin 15 and 16 for SS and INT respectively
+    * Note it uses pin 15 and 0 for SS and INT respectively
+    * Also please be aware that:
+      * GPIO16 is **NOT** usable, as it will be used for some other purposes. For example, reset the SoC itself from sleep mode.
+      * GPIO6 to 11 is also **NOT** usable, as they are used to connect SPI flash chip and it is used for storing the executable binary content.
 
 The following boards need to be activated manually in [settings.h](settings.h):
 

--- a/UsbCore.h
+++ b/UsbCore.h
@@ -40,7 +40,7 @@ typedef MAX3421e<P20, P19> MAX3421E; // Balanduino
 #elif defined(__ARDUINO_X86__) && PLATFORM_ID == 0x06
 typedef MAX3421e<P3, P2> MAX3421E; // The Intel Galileo supports much faster read and write speed at pin 2 and 3
 #elif defined(ESP8266)
-typedef MAX3421e<P15, P16> MAX3421E; // ESP8266 boards
+typedef MAX3421e<P15, P0> MAX3421E; // ESP8266 boards
 #else
 typedef MAX3421e<P10, P9> MAX3421E; // Official Arduinos (UNO, Duemilanove, Mega, 2560, Leonardo, Due etc.), Intel Edison, Intel Galileo 2 or Teensy 2.0 and 3.0
 #endif

--- a/avrpins.h
+++ b/avrpins.h
@@ -1268,23 +1268,18 @@ public: \
 
 // Pinout for ESP-12 module
 // 0 .. 16 - Digital pins
+// GPIO 6 to 11 and 16 are not usable in this library.
+
 MAKE_PIN(P0, 0);
 MAKE_PIN(P1, 1); // TX0
 MAKE_PIN(P2, 2); // TX1
 MAKE_PIN(P3, 3); // RX0
 MAKE_PIN(P4, 4); // SDA
 MAKE_PIN(P5, 5); // SCL
-MAKE_PIN(P6, 6);
-MAKE_PIN(P7, 7);
-MAKE_PIN(P8, 8);
-MAKE_PIN(P9, 9);
-MAKE_PIN(P10, 10);
-MAKE_PIN(P11, 11);
 MAKE_PIN(P12, 12); // MISO
 MAKE_PIN(P13, 13); // MOSI
 MAKE_PIN(P14, 14); // SCK
 MAKE_PIN(P15, 15); // SS
-MAKE_PIN(P16, 16);
 
 #undef MAKE_PIN
 


### PR DESCRIPTION
Hi all,

Due to GPIO 6 to 11 are connected to internal SPI flash in the module and GPIO 16 cannot handle interrupts, we need to change the INT pin to another pin instead. In this occasion, I have changed it to GPIO 0. I haven't tested yet, but it should works.

See here for more details: #262 

Regards,
Jackson Hu.