### PR TITLE
Fixed bug for PS4 Slim controller via USB

### DIFF
--- a/PS4USB.h
+++ b/PS4USB.h
@@ -21,8 +21,9 @@
 #include "hiduniversal.h"
 #include "PS4Parser.h"
 
-#define PS4_VID 0x054C // Sony Corporation
-#define PS4_PID 0x05C4 // PS4 Controller
+#define PS4_VID         0x054C // Sony Corporation
+#define PS4_PID         0x05C4 // PS4 Controller
+#define PS4_PID_SLIM    0x09CC // PS4 Slim Controller
 
 /**
  * This class implements support for the PS4 controller via USB.
@@ -44,7 +45,7 @@ public:
          * @return Returns true if it is connected.
          */
         bool connected() {
-                return HIDUniversal::isReady() && HIDUniversal::VID == PS4_VID && HIDUniversal::PID == PS4_PID;
+                return HIDUniversal::isReady() && HIDUniversal::VID == PS4_VID && (HIDUniversal::PID == PS4_PID || HIDUniversal::PID == PS4_PID_SLIM);
         };
 
         /**
@@ -65,7 +66,7 @@ protected:
          * @param buf       Pointer to the data buffer.
          */
         virtual void ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
-                if (HIDUniversal::VID == PS4_VID && HIDUniversal::PID == PS4_PID)
+                if (HIDUniversal::VID == PS4_VID && (HIDUniversal::PID == PS4_PID || HIDUniversal::PID == PS4_PID_SLIM))
                         PS4Parser::Parse(len, buf);
         };
 
@@ -75,7 +76,7 @@ protected:
          * This is useful for instance if you want to set the LEDs in a specific way.
          */
         virtual uint8_t OnInitSuccessful() {
-                if (HIDUniversal::VID == PS4_VID && HIDUniversal::PID == PS4_PID) {
+                if (HIDUniversal::VID == PS4_VID && (HIDUniversal::PID == PS4_PID || HIDUniversal::PID == PS4_PID_SLIM)) {
                         PS4Parser::Reset();
                         if (pFuncOnInit)
                                 pFuncOnInit(); // Call the user function
@@ -120,7 +121,7 @@ protected:
          * @return     Returns true if the device's VID and PID matches this driver.
          */
         virtual bool VIDPIDOK(uint16_t vid, uint16_t pid) {
-                return (vid == PS4_VID && pid == PS4_PID);
+                return (vid == PS4_VID && (pid == PS4_PID || HIDUniversal::PID == PS4_PID_SLIM));
         };
         /**@}*/
 

--- a/confdescparser.h
+++ b/confdescparser.h
@@ -119,16 +119,13 @@ bool ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::ParseDescriptor
                         switch(dscrType) {
                                 case USB_DESCRIPTOR_INTERFACE:
                                         isGoodInterface = false;
+                                        break;
                                 case USB_DESCRIPTOR_CONFIGURATION:
-                                        theBuffer.valueSize = sizeof (USB_CONFIGURATION_DESCRIPTOR) - 2;
-                                        break;
                                 case USB_DESCRIPTOR_ENDPOINT:
-                                        theBuffer.valueSize = sizeof (USB_ENDPOINT_DESCRIPTOR) - 2;
-                                        break;
                                 case HID_DESCRIPTOR_HID:
-                                        theBuffer.valueSize = dscrLen - 2;
                                         break;
                         }
+                        theBuffer.valueSize = dscrLen - 2;
                         valParser.Initialize(&theBuffer);
                         stateParseDescr = 4;
                 case 4:


### PR DESCRIPTION
Use descriptor length in order to advance the buffer when parsing the descriptors.

This caused an issue with the PS4 Slim controller, as the endpoint descriptor was two bytes longer on the PS4 slim controller when reading the audio interface.

I suspect this is due to the fact that the audio interface (USB descriptor type 0x24) it is currently not supported by the library.

This is similar to what is done in the example as well: https://github.com/felis/USB_Host_Shield_2.0/blob/cbea36f76ffa0a0b1f74eb59e7ec845ccba380aa/examples/USB_desc/USB_desc.ino#L241.

Fixes issue #273.