### PR TITLE
Fix missing unsigned comparison.

### DIFF
--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -96,7 +96,7 @@ void loop()
   Usb.Task();
 
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING ) {
-    if ((millis() - next_time) >= 0L) {
+    if ((long)(millis() - next_time) >= 0L) {
       Usb.ForEachUsbDevice(&PrintAllDescriptors);
       Usb.ForEachUsbDevice(&PrintAllAddresses);
 


### PR DESCRIPTION
next_time value is ignored. This expression is always true.
```
hub_demo.ino:99:32: warning: comparison of unsigned expression >= 0 is always true [-Wtype-limits]

     if ((millis() - next_time) >= 0L) {

                                ^
```