### PR TITLE
Fix millis() and micros() rollover bug

### DIFF
--- a/BTD.cpp
+++ b/BTD.cpp
@@ -384,8 +384,8 @@ uint8_t BTD::Release() {
 uint8_t BTD::Poll() {
         if(!bPollEnable)
                 return 0;
-        if((int32_t)(millis() - qNextPollTime) >= 0L) { // Don't poll if shorter than polling interval
-                qNextPollTime = millis() + pollInterval; // Set new poll time
+        if((int32_t)((uint32_t)millis() - qNextPollTime) >= 0L) { // Don't poll if shorter than polling interval
+                qNextPollTime = (uint32_t)millis() + pollInterval; // Set new poll time
                 HCI_event_task(); // Poll the HCI event pipe
                 HCI_task(); // HCI state machine
                 ACL_event_task(); // Poll the ACL input pipe too

--- a/BTD.cpp
+++ b/BTD.cpp
@@ -384,7 +384,7 @@ uint8_t BTD::Release() {
 uint8_t BTD::Poll() {
         if(!bPollEnable)
                 return 0;
-        if((long)(millis() - qNextPollTime) >= 0L) { // Don't poll if shorter than polling interval
+        if((int32_t)(millis() - qNextPollTime) >= 0L) { // Don't poll if shorter than polling interval
                 qNextPollTime = millis() + pollInterval; // Set new poll time
                 HCI_event_task(); // Poll the HCI event pipe
                 HCI_task(); // HCI state machine

--- a/PS3BT.cpp
+++ b/PS3BT.cpp
@@ -454,7 +454,7 @@ void PS3BT::L2CAP_task() {
 void PS3BT::Run() {
         switch(l2cap_state) {
                 case PS3_ENABLE_SIXAXIS:
-                        if(millis() - timer > 1000) { // loop 1 second before sending the command
+                        if((int32_t)(millis() - timer) > 1000) { // loop 1 second before sending the command
                                 memset(l2capinbuf, 0, BULK_MAXPKTSIZE); // Reset l2cap in buffer as it sometimes read it as a button has been pressed
                                 for(uint8_t i = 15; i < 19; i++)
                                         l2capinbuf[i] = 0x7F; // Set the analog joystick values to center position
@@ -465,7 +465,7 @@ void PS3BT::Run() {
                         break;
 
                 case TURN_ON_LED:
-                        if(millis() - timer > 1000) { // loop 1 second before sending the command
+                        if((int32_t)(millis() - timer) > 1000) { // loop 1 second before sending the command
                                 if(remote_name_first == 'P') { // First letter in PLAYSTATION(R)3 Controller ('P')
 #ifdef DEBUG_USB_HOST
                                         Notify(PSTR("\r\nDualshock 3 Controller Enabled\r\n"), 0x80);
@@ -494,7 +494,7 @@ void PS3BT::Run() {
 
                 case L2CAP_DONE:
                         if(PS3MoveConnected) { // The Bulb and rumble values, has to be send at approximately every 5th second for it to stay on
-                                if(millis() - timer > 4000) { // Send at least every 4th second
+                                if((int32_t)(millis() - timer) > 4000) { // Send at least every 4th second
                                         HIDMove_Command(HIDMoveBuffer, HID_BUFFERSIZE); // The Bulb and rumble values, has to be written again and again, for it to stay turned on
                                         timer = millis();
                                 }
@@ -510,7 +510,7 @@ void PS3BT::Run() {
 // Playstation Sixaxis Dualshock and Navigation Controller commands
 
 void PS3BT::HID_Command(uint8_t* data, uint8_t nbytes) {
-        if(millis() - timerHID <= 150) // Check if is has been more than 150ms since last command
+        if((int32_t)(millis() - timerHID) <= 150) // Check if is has been more than 150ms since last command
                 delay((uint32_t)(150 - (millis() - timerHID))); // There have to be a delay between commands
         pBtd->L2CAP_Command(hci_handle, data, nbytes, control_scid[0], control_scid[1]); // Both the Navigation and Dualshock controller sends data via the control channel
         timerHID = millis();
@@ -595,7 +595,7 @@ void PS3BT::enable_sixaxis() { // Command used to enable the Dualshock 3 and Nav
 // Playstation Move Controller commands
 
 void PS3BT::HIDMove_Command(uint8_t* data, uint8_t nbytes) {
-        if(millis() - timerHID <= 150)// Check if is has been less than 150ms since last command
+        if((int32_t)(millis() - timerHID) <= 150)// Check if is has been less than 150ms since last command
                 delay((uint32_t)(150 - (millis() - timerHID))); // There have to be a delay between commands
         pBtd->L2CAP_Command(hci_handle, data, nbytes, interrupt_scid[0], interrupt_scid[1]); // The Move controller sends it's data via the intterrupt channel
         timerHID = millis();

--- a/PS3BT.cpp
+++ b/PS3BT.cpp
@@ -339,7 +339,7 @@ void PS3BT::ACLData(uint8_t* ACLData) {
                         if(PS3Connected || PS3MoveConnected || PS3NavigationConnected) {
                                 /* Read Report */
                                 if(l2capinbuf[8] == 0xA1) { // HID_THDR_DATA_INPUT
-                                        lastMessageTime = millis(); // Store the last message time
+                                        lastMessageTime = (uint32_t)millis(); // Store the last message time
 
                                         if(PS3Connected || PS3NavigationConnected)
                                                 ButtonState = (uint32_t)(l2capinbuf[11] | ((uint16_t)l2capinbuf[12] << 8) | ((uint32_t)l2capinbuf[13] << 16));
@@ -420,7 +420,7 @@ void PS3BT::L2CAP_task() {
                                         l2cap_state = TURN_ON_LED;
                                 } else
                                         l2cap_state = PS3_ENABLE_SIXAXIS;
-                                timer = millis();
+                                timer = (uint32_t)millis();
                         }
                         break;
 
@@ -454,18 +454,18 @@ void PS3BT::L2CAP_task() {
 void PS3BT::Run() {
         switch(l2cap_state) {
                 case PS3_ENABLE_SIXAXIS:
-                        if((int32_t)(millis() - timer) > 1000) { // loop 1 second before sending the command
+                        if((int32_t)((uint32_t)millis() - timer) > 1000) { // loop 1 second before sending the command
                                 memset(l2capinbuf, 0, BULK_MAXPKTSIZE); // Reset l2cap in buffer as it sometimes read it as a button has been pressed
                                 for(uint8_t i = 15; i < 19; i++)
                                         l2capinbuf[i] = 0x7F; // Set the analog joystick values to center position
                                 enable_sixaxis();
                                 l2cap_state = TURN_ON_LED;
-                                timer = millis();
+                                timer = (uint32_t)millis();
                         }
                         break;
 
                 case TURN_ON_LED:
-                        if((int32_t)(millis() - timer) > 1000) { // loop 1 second before sending the command
+                        if((int32_t)((uint32_t)millis() - timer) > 1000) { // loop 1 second before sending the command
                                 if(remote_name_first == 'P') { // First letter in PLAYSTATION(R)3 Controller ('P')
 #ifdef DEBUG_USB_HOST
                                         Notify(PSTR("\r\nDualshock 3 Controller Enabled\r\n"), 0x80);
@@ -477,7 +477,7 @@ void PS3BT::Run() {
 #endif
                                         PS3NavigationConnected = true;
                                 } else if(remote_name_first == 'M') { // First letter in Motion Controller ('M')
-                                        timer = millis();
+                                        timer = (uint32_t)millis();
 #ifdef DEBUG_USB_HOST
                                         Notify(PSTR("\r\nMotion Controller Enabled\r\n"), 0x80);
 #endif
@@ -494,9 +494,9 @@ void PS3BT::Run() {
 
                 case L2CAP_DONE:
                         if(PS3MoveConnected) { // The Bulb and rumble values, has to be send at approximately every 5th second for it to stay on
-                                if((int32_t)(millis() - timer) > 4000) { // Send at least every 4th second
+                                if((int32_t)((uint32_t)millis() - timer) > 4000) { // Send at least every 4th second
                                         HIDMove_Command(HIDMoveBuffer, HID_BUFFERSIZE); // The Bulb and rumble values, has to be written again and again, for it to stay turned on
-                                        timer = millis();
+                                        timer = (uint32_t)millis();
                                 }
                         }
                         break;
@@ -510,10 +510,10 @@ void PS3BT::Run() {
 // Playstation Sixaxis Dualshock and Navigation Controller commands
 
 void PS3BT::HID_Command(uint8_t* data, uint8_t nbytes) {
-        if((int32_t)(millis() - timerHID) <= 150) // Check if is has been more than 150ms since last command
-                delay((uint32_t)(150 - (millis() - timerHID))); // There have to be a delay between commands
+        if((int32_t)((uint32_t)millis() - timerHID) <= 150) // Check if is has been more than 150ms since last command
+                delay((uint32_t)(150 - ((uint32_t)millis() - timerHID))); // There have to be a delay between commands
         pBtd->L2CAP_Command(hci_handle, data, nbytes, control_scid[0], control_scid[1]); // Both the Navigation and Dualshock controller sends data via the control channel
-        timerHID = millis();
+        timerHID = (uint32_t)millis();
 }
 
 void PS3BT::setAllOff() {
@@ -595,10 +595,10 @@ void PS3BT::enable_sixaxis() { // Command used to enable the Dualshock 3 and Nav
 // Playstation Move Controller commands
 
 void PS3BT::HIDMove_Command(uint8_t* data, uint8_t nbytes) {
-        if((int32_t)(millis() - timerHID) <= 150)// Check if is has been less than 150ms since last command
-                delay((uint32_t)(150 - (millis() - timerHID))); // There have to be a delay between commands
+        if((int32_t)((uint32_t)millis() - timerHID) <= 150)// Check if is has been less than 150ms since last command
+                delay((uint32_t)(150 - ((uint32_t)millis() - timerHID))); // There have to be a delay between commands
         pBtd->L2CAP_Command(hci_handle, data, nbytes, interrupt_scid[0], interrupt_scid[1]); // The Move controller sends it's data via the intterrupt channel
-        timerHID = millis();
+        timerHID = (uint32_t)millis();
 }
 
 void PS3BT::moveSetBulb(uint8_t r, uint8_t g, uint8_t b) { // Use this to set the Color using RGB values

--- a/PS3USB.cpp
+++ b/PS3USB.cpp
@@ -276,14 +276,14 @@ uint8_t PS3USB::Poll() {
         if(PS3Connected || PS3NavigationConnected) {
                 uint16_t BUFFER_SIZE = EP_MAXPKTSIZE;
                 pUsb->inTransfer(bAddress, epInfo[ PS3_INPUT_PIPE ].epAddr, &BUFFER_SIZE, readBuf); // input on endpoint 1
-                if(millis() - timer > 100) { // Loop 100ms before processing data
+                if((int32_t)(millis() - timer) > 100) { // Loop 100ms before processing data
                         readReport();
 #ifdef PRINTREPORT
                         printReport(); // Uncomment "#define PRINTREPORT" to print the report send by the PS3 Controllers
 #endif
                 }
         } else if(PS3MoveConnected) { // One can only set the color of the bulb, set the rumble, set and get the bluetooth address and calibrate the magnetometer via USB
-                if(millis() - timer > 4000) { // Send at least every 4th second
+                if((int32_t)(millis() - timer) > 4000) { // Send at least every 4th second
                         Move_Command(writeBuf, MOVE_REPORT_BUFFER_SIZE); // The Bulb and rumble values, has to be written again and again, for it to stay turned on
                         timer = millis();
                 }

--- a/PS3USB.cpp
+++ b/PS3USB.cpp
@@ -221,7 +221,7 @@ uint8_t PS3USB::Init(uint8_t parent, uint8_t port, bool lowspeed) {
 
         bPollEnable = true;
         Notify(PSTR("\r\n"), 0x80);
-        timer = millis();
+        timer = (uint32_t)millis();
         return 0; // Successful configuration
 
         /* Diagnostic messages */
@@ -276,16 +276,16 @@ uint8_t PS3USB::Poll() {
         if(PS3Connected || PS3NavigationConnected) {
                 uint16_t BUFFER_SIZE = EP_MAXPKTSIZE;
                 pUsb->inTransfer(bAddress, epInfo[ PS3_INPUT_PIPE ].epAddr, &BUFFER_SIZE, readBuf); // input on endpoint 1
-                if((int32_t)(millis() - timer) > 100) { // Loop 100ms before processing data
+                if((int32_t)((uint32_t)millis() - timer) > 100) { // Loop 100ms before processing data
                         readReport();
 #ifdef PRINTREPORT
                         printReport(); // Uncomment "#define PRINTREPORT" to print the report send by the PS3 Controllers
 #endif
                 }
         } else if(PS3MoveConnected) { // One can only set the color of the bulb, set the rumble, set and get the bluetooth address and calibrate the magnetometer via USB
-                if((int32_t)(millis() - timer) > 4000) { // Send at least every 4th second
+                if((int32_t)((uint32_t)millis() - timer) > 4000) { // Send at least every 4th second
                         Move_Command(writeBuf, MOVE_REPORT_BUFFER_SIZE); // The Bulb and rumble values, has to be written again and again, for it to stay turned on
-                        timer = millis();
+                        timer = (uint32_t)millis();
                 }
         }
         return 0;

--- a/SPP.cpp
+++ b/SPP.cpp
@@ -421,7 +421,7 @@ void SPP::ACLData(uint8_t* l2capinbuf) {
 }
 
 void SPP::Run() {
-        if(waitForLastCommand && (millis() - timer) > 100) { // We will only wait 100ms and see if the UIH Remote Port Negotiation Command is send, as some deviced don't send it
+        if(waitForLastCommand && (int32_t)(millis() - timer) > 100) { // We will only wait 100ms and see if the UIH Remote Port Negotiation Command is send, as some deviced don't send it
 #ifdef DEBUG_USB_HOST
                 Notify(PSTR("\r\nRFCOMM Connection is now established - Automatic\r\n"), 0x80);
 #endif

--- a/SPP.cpp
+++ b/SPP.cpp
@@ -370,7 +370,7 @@ void SPP::ACLData(uint8_t* l2capinbuf) {
 #endif
                                                 sendRfcommCredit(rfcommChannelConnection, rfcommDirection, 0, RFCOMM_UIH, 0x10, sizeof (rfcommDataBuffer)); // Send credit
                                                 creditSent = true;
-                                                timer = millis();
+                                                timer = (uint32_t)millis();
                                                 waitForLastCommand = true;
                                         }
                                 } else if(rfcommChannelType == RFCOMM_UIH && l2capinbuf[10] == 0x01) { // UIH Command with credit
@@ -421,7 +421,7 @@ void SPP::ACLData(uint8_t* l2capinbuf) {
 }
 
 void SPP::Run() {
-        if(waitForLastCommand && (int32_t)(millis() - timer) > 100) { // We will only wait 100ms and see if the UIH Remote Port Negotiation Command is send, as some deviced don't send it
+        if(waitForLastCommand && (int32_t)((uint32_t)millis() - timer) > 100) { // We will only wait 100ms and see if the UIH Remote Port Negotiation Command is send, as some deviced don't send it
 #ifdef DEBUG_USB_HOST
                 Notify(PSTR("\r\nRFCOMM Connection is now established - Automatic\r\n"), 0x80);
 #endif

--- a/Usb.cpp
+++ b/Usb.cpp
@@ -313,7 +313,7 @@ uint8_t USB::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8
         if(maxpktsize < 1 || maxpktsize > 64)
                 return USB_ERROR_INVALID_MAX_PKT_SIZE;
 
-        unsigned long timeout = millis() + USB_XFER_TIMEOUT;
+        uint32_t timeout = millis() + USB_XFER_TIMEOUT;
 
         regWr(rHCTL, (pep->bmSndToggle) ? bmSNDTOG1 : bmSNDTOG0); //set toggle value
 
@@ -328,7 +328,7 @@ uint8_t USB::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8
                 regWr(rHIRQ, bmHXFRDNIRQ); //clear IRQ
                 rcode = (regRd(rHRSL) & 0x0f);
 
-                while(rcode && ((long)(millis() - timeout) < 0L)) {
+                while(rcode && ((int32_t)(millis() - timeout) < 0L)) {
                         switch(rcode) {
                                 case hrNAK:
                                         nak_count++;
@@ -375,17 +375,17 @@ breakout:
 
 /* return codes 0x00-0x0f are HRSLT( 0x00 being success ), 0xff means timeout                       */
 uint8_t USB::dispatchPkt(uint8_t token, uint8_t ep, uint16_t nak_limit) {
-        unsigned long timeout = millis() + USB_XFER_TIMEOUT;
+        uint32_t timeout = millis() + USB_XFER_TIMEOUT;
         uint8_t tmpdata;
         uint8_t rcode = hrSUCCESS;
         uint8_t retry_count = 0;
         uint16_t nak_count = 0;
 
-        while((long)(millis() - timeout) < 0L) {
+        while((int32_t)(millis() - timeout) < 0L) {
                 regWr(rHXFR, (token | ep)); //launch the transfer
                 rcode = USB_ERROR_TRANSFER_TIMEOUT;
 
-                while((long)(millis() - timeout) < 0L) //wait for transfer completion
+                while((int32_t)(millis() - timeout) < 0L) //wait for transfer completion
                 {
                         tmpdata = regRd(rHIRQ);
 
@@ -476,7 +476,7 @@ void USB::Task(void) //USB state machine
                 case USB_DETACHED_SUBSTATE_ILLEGAL: //just sit here
                         break;
                 case USB_ATTACHED_SUBSTATE_SETTLE: //settle time for just attached device
-                        if((long)(millis() - delay) >= 0L)
+                        if((int32_t)(millis() - delay) >= 0L)
                                 usb_task_state = USB_ATTACHED_SUBSTATE_RESET_DEVICE;
                         else break; // don't fall through
                 case USB_ATTACHED_SUBSTATE_RESET_DEVICE:
@@ -503,7 +503,7 @@ void USB::Task(void) //USB state machine
                         }
                         break;
                 case USB_ATTACHED_SUBSTATE_WAIT_RESET:
-                        if((long)(millis() - delay) >= 0L) usb_task_state = USB_STATE_CONFIGURING;
+                        if((int32_t)(millis() - delay) >= 0L) usb_task_state = USB_STATE_CONFIGURING;
                         else break; // don't fall through
                 case USB_STATE_CONFIGURING:
 

--- a/Usb.cpp
+++ b/Usb.cpp
@@ -313,7 +313,7 @@ uint8_t USB::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8
         if(maxpktsize < 1 || maxpktsize > 64)
                 return USB_ERROR_INVALID_MAX_PKT_SIZE;
 
-        uint32_t timeout = millis() + USB_XFER_TIMEOUT;
+        uint32_t timeout = (uint32_t)millis() + USB_XFER_TIMEOUT;
 
         regWr(rHCTL, (pep->bmSndToggle) ? bmSNDTOG1 : bmSNDTOG0); //set toggle value
 
@@ -328,7 +328,7 @@ uint8_t USB::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8
                 regWr(rHIRQ, bmHXFRDNIRQ); //clear IRQ
                 rcode = (regRd(rHRSL) & 0x0f);
 
-                while(rcode && ((int32_t)(millis() - timeout) < 0L)) {
+                while(rcode && ((int32_t)((uint32_t)millis() - timeout) < 0L)) {
                         switch(rcode) {
                                 case hrNAK:
                                         nak_count++;
@@ -375,17 +375,17 @@ breakout:
 
 /* return codes 0x00-0x0f are HRSLT( 0x00 being success ), 0xff means timeout                       */
 uint8_t USB::dispatchPkt(uint8_t token, uint8_t ep, uint16_t nak_limit) {
-        uint32_t timeout = millis() + USB_XFER_TIMEOUT;
+        uint32_t timeout = (uint32_t)millis() + USB_XFER_TIMEOUT;
         uint8_t tmpdata;
         uint8_t rcode = hrSUCCESS;
         uint8_t retry_count = 0;
         uint16_t nak_count = 0;
 
-        while((int32_t)(millis() - timeout) < 0L) {
+        while((int32_t)((uint32_t)millis() - timeout) < 0L) {
                 regWr(rHXFR, (token | ep)); //launch the transfer
                 rcode = USB_ERROR_TRANSFER_TIMEOUT;
 
-                while((int32_t)(millis() - timeout) < 0L) //wait for transfer completion
+                while((int32_t)((uint32_t)millis() - timeout) < 0L) //wait for transfer completion
                 {
                         tmpdata = regRd(rHIRQ);
 
@@ -451,7 +451,7 @@ void USB::Task(void) //USB state machine
                         //intentional fallthrough
                 case FSHOST: //attached
                         if((usb_task_state & USB_STATE_MASK) == USB_STATE_DETACHED) {
-                                delay = millis() + USB_SETTLE_DELAY;
+                                delay = (uint32_t)millis() + USB_SETTLE_DELAY;
                                 usb_task_state = USB_ATTACHED_SUBSTATE_SETTLE;
                         }
                         break;
@@ -476,7 +476,7 @@ void USB::Task(void) //USB state machine
                 case USB_DETACHED_SUBSTATE_ILLEGAL: //just sit here
                         break;
                 case USB_ATTACHED_SUBSTATE_SETTLE: //settle time for just attached device
-                        if((int32_t)(millis() - delay) >= 0L)
+                        if((int32_t)((uint32_t)millis() - delay) >= 0L)
                                 usb_task_state = USB_ATTACHED_SUBSTATE_RESET_DEVICE;
                         else break; // don't fall through
                 case USB_ATTACHED_SUBSTATE_RESET_DEVICE:
@@ -488,22 +488,22 @@ void USB::Task(void) //USB state machine
                                 tmpdata = regRd(rMODE) | bmSOFKAENAB; //start SOF generation
                                 regWr(rMODE, tmpdata);
                                 usb_task_state = USB_ATTACHED_SUBSTATE_WAIT_SOF;
-                                //delay = millis() + 20; //20ms wait after reset per USB spec
+                                //delay = (uint32_t)millis() + 20; //20ms wait after reset per USB spec
                         }
                         break;
                 case USB_ATTACHED_SUBSTATE_WAIT_SOF: //todo: change check order
                         if(regRd(rHIRQ) & bmFRAMEIRQ) {
                                 //when first SOF received _and_ 20ms has passed we can continue
                                 /*
-                                if (delay < millis()) //20ms passed
+                                if (delay < (uint32_t)millis()) //20ms passed
                                         usb_task_state = USB_STATE_CONFIGURING;
                                  */
                                 usb_task_state = USB_ATTACHED_SUBSTATE_WAIT_RESET;
-                                delay = millis() + 20;
+                                delay = (uint32_t)millis() + 20;
                         }
                         break;
                 case USB_ATTACHED_SUBSTATE_WAIT_RESET:
-                        if((int32_t)(millis() - delay) >= 0L) usb_task_state = USB_STATE_CONFIGURING;
+                        if((int32_t)((uint32_t)millis() - delay) >= 0L) usb_task_state = USB_STATE_CONFIGURING;
                         else break; // don't fall through
                 case USB_STATE_CONFIGURING:
 

--- a/Usb.cpp
+++ b/Usb.cpp
@@ -426,7 +426,7 @@ void USB::Task(void) //USB state machine
 {
         uint8_t rcode;
         uint8_t tmpdata;
-        static unsigned long delay = 0;
+        static uint32_t delay = 0;
         //USB_DEVICE_DESCRIPTOR buf;
         bool lowspeed = false;
 

--- a/Wii.cpp
+++ b/Wii.cpp
@@ -121,9 +121,9 @@ void WII::disconnect() { // Use this void to disconnect any of the controllers
 #endif
                         initExtension1(); // This will disable the Motion Plus extension
                 }
-                timer = millis() + 1000; // We have to wait for the message before the rest of the channels can be deactivated
+                timer = (uint32_t)millis() + 1000; // We have to wait for the message before the rest of the channels can be deactivated
         } else
-                timer = millis(); // Don't wait
+                timer = (uint32_t)millis(); // Don't wait
         // First the HID interrupt channel has to be disconnected, then the HID control channel and finally the HCI connection
         pBtd->l2cap_disconnection_request(hci_handle, ++identifier, interrupt_scid, interrupt_dcid);
         Reset();
@@ -522,13 +522,13 @@ void WII::ACLData(uint8_t* l2capinbuf) {
                                                                         if(!(l2capinbuf[19] & 0x02)) // Check if fast mode is used
                                                                                 rollGyroSpeed *= 4.545;
 
-                                                                        compPitch = (0.93f * (compPitch + (pitchGyroSpeed * (float)(micros() - timer) / 1000000.0f)))+(0.07f * getWiimotePitch()); // Use a complimentary filter to calculate the angle
-                                                                        compRoll = (0.93f * (compRoll + (rollGyroSpeed * (float)(micros() - timer) / 1000000.0f)))+(0.07f * getWiimoteRoll());
+                                                                        compPitch = (0.93f * (compPitch + (pitchGyroSpeed * (float)((uint32_t)micros() - timer) / 1000000.0f)))+(0.07f * getWiimotePitch()); // Use a complimentary filter to calculate the angle
+                                                                        compRoll = (0.93f * (compRoll + (rollGyroSpeed * (float)((uint32_t)micros() - timer) / 1000000.0f)))+(0.07f * getWiimoteRoll());
 
-                                                                        gyroYaw += (yawGyroSpeed * ((float)(micros() - timer) / 1000000.0f));
-                                                                        gyroRoll += (rollGyroSpeed * ((float)(micros() - timer) / 1000000.0f));
-                                                                        gyroPitch += (pitchGyroSpeed * ((float)(micros() - timer) / 1000000.0f));
-                                                                        timer = micros();
+                                                                        gyroYaw += (yawGyroSpeed * ((float)((uint32_t)micros() - timer) / 1000000.0f));
+                                                                        gyroRoll += (rollGyroSpeed * ((float)((uint32_t)micros() - timer) / 1000000.0f));
+                                                                        gyroPitch += (pitchGyroSpeed * ((float)((uint32_t)micros() - timer) / 1000000.0f));
+                                                                        timer = (uint32_t)micros();
                                                                         /*
                                                                         // Uncomment these lines to tune the gyro scale variabels
                                                                         Notify(PSTR("\r\ngyroYaw: "), 0x80);
@@ -545,7 +545,7 @@ void WII::ACLData(uint8_t* l2capinbuf) {
                                                                         Notify(wiimotePitch, 0x80);
                                                                          */
                                                                 } else {
-                                                                        if((int32_t)(micros() - timer) > 1000000) { // Loop for 1 sec before resetting the values
+                                                                        if((int32_t)((uint32_t)micros() - timer) > 1000000) { // Loop for 1 sec before resetting the values
 #ifdef DEBUG_USB_HOST
                                                                                 Notify(PSTR("\r\nThe gyro values has been reset"), 0x80);
 #endif
@@ -562,7 +562,7 @@ void WII::ACLData(uint8_t* l2capinbuf) {
                                                                                 gyroPitch = 0;
 
                                                                                 motionValuesReset = true;
-                                                                                timer = micros();
+                                                                                timer = (uint32_t)micros();
                                                                         }
                                                                 }
                                                         } else {
@@ -698,7 +698,7 @@ void WII::L2CAP_task() {
                         /* The next states are in run() */
 
                 case L2CAP_INTERRUPT_DISCONNECT:
-                        if(l2cap_check_flag(L2CAP_FLAG_DISCONNECT_INTERRUPT_RESPONSE) && ((int32_t)(millis() - timer) >= 0L)) {
+                        if(l2cap_check_flag(L2CAP_FLAG_DISCONNECT_INTERRUPT_RESPONSE) && ((int32_t)((uint32_t)millis() - timer) >= 0L)) {
 #ifdef DEBUG_USB_HOST
                                 Notify(PSTR("\r\nDisconnected Interrupt Channel"), 0x80);
 #endif
@@ -723,7 +723,7 @@ void WII::L2CAP_task() {
 }
 
 void WII::Run() {
-        if(l2cap_state == L2CAP_INTERRUPT_DISCONNECT && ((int32_t)(millis() - timer) >= 0L))
+        if(l2cap_state == L2CAP_INTERRUPT_DISCONNECT && ((int32_t)((uint32_t)millis() - timer) >= 0L))
                 L2CAP_task(); // Call the rest of the disconnection routine after we have waited long enough
 
         switch(l2cap_state) {
@@ -765,7 +765,7 @@ void WII::Run() {
                         if(wii_check_flag(WII_FLAG_MOTION_PLUS_CONNECTED)) {
                                 stateCounter = 0;
                                 l2cap_state = WII_INIT_MOTION_PLUS_STATE;
-                                timer = micros();
+                                timer = (uint32_t)micros();
 
                                 if(unknownExtensionConnected) {
 #ifdef DEBUG_USB_HOST

--- a/Wii.cpp
+++ b/Wii.cpp
@@ -545,7 +545,7 @@ void WII::ACLData(uint8_t* l2capinbuf) {
                                                                         Notify(wiimotePitch, 0x80);
                                                                          */
                                                                 } else {
-                                                                        if((micros() - timer) > 1000000) { // Loop for 1 sec before resetting the values
+                                                                        if((int32_t)(micros() - timer) > 1000000) { // Loop for 1 sec before resetting the values
 #ifdef DEBUG_USB_HOST
                                                                                 Notify(PSTR("\r\nThe gyro values has been reset"), 0x80);
 #endif
@@ -698,7 +698,7 @@ void WII::L2CAP_task() {
                         /* The next states are in run() */
 
                 case L2CAP_INTERRUPT_DISCONNECT:
-                        if(l2cap_check_flag(L2CAP_FLAG_DISCONNECT_INTERRUPT_RESPONSE) && ((long)(millis() - timer) >= 0L)) {
+                        if(l2cap_check_flag(L2CAP_FLAG_DISCONNECT_INTERRUPT_RESPONSE) && ((int32_t)(millis() - timer) >= 0L)) {
 #ifdef DEBUG_USB_HOST
                                 Notify(PSTR("\r\nDisconnected Interrupt Channel"), 0x80);
 #endif
@@ -723,7 +723,7 @@ void WII::L2CAP_task() {
 }
 
 void WII::Run() {
-        if(l2cap_state == L2CAP_INTERRUPT_DISCONNECT && ((long)(millis() - timer) >= 0L))
+        if(l2cap_state == L2CAP_INTERRUPT_DISCONNECT && ((int32_t)(millis() - timer) >= 0L))
                 L2CAP_task(); // Call the rest of the disconnection routine after we have waited long enough
 
         switch(l2cap_state) {

--- a/XBOXRECV.cpp
+++ b/XBOXRECV.cpp
@@ -293,8 +293,8 @@ uint8_t XBOXRECV::Release() {
 uint8_t XBOXRECV::Poll() {
         if(!bPollEnable)
                 return 0;
-        if(!checkStatusTimer || ((int32_t)(millis() - checkStatusTimer) > 3000)) { // Run checkStatus every 3 seconds
-                checkStatusTimer = millis();
+        if(!checkStatusTimer || ((int32_t)((uint32_t)millis() - checkStatusTimer) > 3000)) { // Run checkStatus every 3 seconds
+                checkStatusTimer = (uint32_t)millis();
                 checkStatus();
         }
 

--- a/XBOXRECV.cpp
+++ b/XBOXRECV.cpp
@@ -293,7 +293,7 @@ uint8_t XBOXRECV::Release() {
 uint8_t XBOXRECV::Poll() {
         if(!bPollEnable)
                 return 0;
-        if(!checkStatusTimer || ((millis() - checkStatusTimer) > 3000)) { // Run checkStatus every 3 seconds
+        if(!checkStatusTimer || ((int32_t)(millis() - checkStatusTimer) > 3000)) { // Run checkStatus every 3 seconds
                 checkStatusTimer = millis();
                 checkStatus();
         }

--- a/cdcftdi.cpp
+++ b/cdcftdi.cpp
@@ -290,8 +290,8 @@ uint8_t FTDI::SetBaudRate(uint32_t baud) {
                         if(divisor3 != 0) baud_value |= 0x8000; // 0.25
                 if(baud_value == 1) baud_value = 0; /* special case for maximum baud rate */
         } else {
-                static const unsigned char divfrac [8] = {0, 3, 2, 0, 1, 1, 2, 3};
-                static const unsigned char divindex[8] = {0, 0, 0, 1, 0, 1, 1, 1};
+                static const uint8_t divfrac [8] = {0, 3, 2, 0, 1, 1, 2, 3};
+                static const uint8_t divindex[8] = {0, 0, 0, 1, 0, 1, 1, 1};
 
                 baud_value = divisor3 >> 3;
                 baud_value |= divfrac [divisor3 & 0x7] << 14;

--- a/cdcftdi.cpp
+++ b/cdcftdi.cpp
@@ -261,11 +261,11 @@ uint8_t FTDI::Poll() {
         //if (!bPollEnable)
         //      return 0;
 
-        //if (qNextPollTime <= millis())
+        //if (qNextPollTime <= (uint32_t)millis())
         //{
         //      USB_HOST_SERIAL.println(bAddress, HEX);
 
-        //      qNextPollTime = millis() + 100;
+        //      qNextPollTime = (uint32_t)millis() + 100;
         //}
         return rcode;
 }

--- a/cdcprolific.cpp
+++ b/cdcprolific.cpp
@@ -237,11 +237,11 @@ Fail:
 //      //if (!bPollEnable)
 //      //      return 0;
 //
-//      //if (qNextPollTime <= millis())
+//      //if (qNextPollTime <= (uint32_t)millis())
 //      //{
 //      //      USB_HOST_SERIAL.println(bAddress, HEX);
 //
-//      //      qNextPollTime = millis() + 100;
+//      //      qNextPollTime = (uint32_t)millis() + 100;
 //      //}
 //      return rcode;
 //}

--- a/examples/HID/SRWS1/SRWS1.ino
+++ b/examples/HID/SRWS1/SRWS1.ino
@@ -33,8 +33,8 @@ void loop() {
       Serial.println(srw1.srws1Data.tilt);
     } else { // Show strobe light effect
       static uint32_t timer;
-      if ((int32_t)(millis() - timer) > 12) {
-        timer = millis(); // Reset timer
+      if ((int32_t)((uint32_t)millis() - timer) > 12) {
+        timer = (uint32_t)millis(); // Reset timer
 
         static uint16_t leds = 0;
         //PrintHex<uint16_t > (leds, 0x80); Serial.println();

--- a/examples/HID/SRWS1/SRWS1.ino
+++ b/examples/HID/SRWS1/SRWS1.ino
@@ -33,7 +33,7 @@ void loop() {
       Serial.println(srw1.srws1Data.tilt);
     } else { // Show strobe light effect
       static uint32_t timer;
-      if (millis() - timer > 12) {
+      if ((int32_t)(millis() - timer) > 12) {
         timer = millis(); // Reset timer
 
         static uint16_t leds = 0;

--- a/examples/HID/USBHIDBootKbd/USBHIDBootKbd.ino
+++ b/examples/HID/USBHIDBootKbd/USBHIDBootKbd.ino
@@ -100,8 +100,6 @@ USB     Usb;
 //USBHub     Hub(&Usb);
 HIDBoot<USB_HID_PROTOCOL_KEYBOARD>    HidKeyboard(&Usb);
 
-uint32_t next_time;
-
 KbdRptParser Prs;
 
 void setup()
@@ -116,8 +114,6 @@ void setup()
     Serial.println("OSC did not start.");
 
   delay( 200 );
-
-  next_time = millis() + 5000;
 
   HidKeyboard.SetReportParser(0, &Prs);
 }

--- a/examples/HID/USBHIDBootKbdAndMouse/USBHIDBootKbdAndMouse.ino
+++ b/examples/HID/USBHIDBootKbdAndMouse/USBHIDBootKbdAndMouse.ino
@@ -145,8 +145,6 @@ HIDBoot < USB_HID_PROTOCOL_KEYBOARD | USB_HID_PROTOCOL_MOUSE > HidComposite(&Usb
 HIDBoot<USB_HID_PROTOCOL_KEYBOARD>    HidKeyboard(&Usb);
 HIDBoot<USB_HID_PROTOCOL_MOUSE>    HidMouse(&Usb);
 
-//uint32_t next_time;
-
 KbdRptParser KbdPrs;
 MouseRptParser MousePrs;
 
@@ -162,8 +160,6 @@ void setup()
     Serial.println("OSC did not start.");
 
   delay( 200 );
-
-  //next_time = millis() + 5000;
 
   HidComposite.SetReportParser(0, &KbdPrs);
   HidComposite.SetReportParser(1, &MousePrs);

--- a/examples/HID/USBHIDBootMouse/USBHIDBootMouse.ino
+++ b/examples/HID/USBHIDBootMouse/USBHIDBootMouse.ino
@@ -54,8 +54,6 @@ USB     Usb;
 USBHub     Hub(&Usb);
 HIDBoot<USB_HID_PROTOCOL_MOUSE>    HidMouse(&Usb);
 
-uint32_t next_time;
-
 MouseRptParser                               Prs;
 
 void setup()
@@ -70,8 +68,6 @@ void setup()
         Serial.println("OSC did not start.");
 
     delay( 200 );
-
-    next_time = millis() + 5000;
 
     HidMouse.SetReportParser(0, &Prs);
 }

--- a/examples/USBH_MIDI/USBH_MIDI_dump/USBH_MIDI_dump.ino
+++ b/examples/USBH_MIDI/USBH_MIDI_dump/USBH_MIDI_dump.ino
@@ -24,7 +24,7 @@ USB Usb;
 USBH_MIDI  Midi(&Usb);
 
 void MIDI_poll();
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime);
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime);
 
 boolean bFirst;
 uint16_t pid, vid;
@@ -77,9 +77,9 @@ void MIDI_poll()
 }
 
 // Delay time (max 16383 us)
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime)
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime)
 {
-  unsigned long t3;
+  uint32_t t3;
 
   if ( t1 > t2 ) {
     t3 = (0xFFFFFFFF - t1 + t2);

--- a/examples/USBH_MIDI/USBH_MIDI_dump/USBH_MIDI_dump.ino
+++ b/examples/USBH_MIDI/USBH_MIDI_dump/USBH_MIDI_dump.ino
@@ -43,16 +43,11 @@ void setup()
 
 void loop()
 {
-  //unsigned long t1;
-
   Usb.Task();
-  //t1 = micros();
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
   {
     MIDI_poll();
   }
-  //delay(1ms)
-  //doDelay(t1, micros(), 1000);
 }
 
 // Poll USB MIDI Controler and send to serial MIDI
@@ -69,11 +64,7 @@ void MIDI_poll()
     pid = Midi.pid;
   }
   if (Midi.RecvData( &rcvd,  bufMidi) == 0 ) {
-#ifdef __ARDUINO_ARC__
-    sprintf(buf, "%016llX: ", millis()); // millis() is 64-bits on the Arduino/Genuino 101
-#else
-    sprintf(buf, "%08lX: ", millis());
-#endif
+    sprintf(buf, "%08lX: ", (uint32_t)millis());
     Serial.print(buf);
     Serial.print(rcvd);
     Serial.print(':');

--- a/examples/USBH_MIDI/USB_MIDI_converter/USB_MIDI_converter.ino
+++ b/examples/USBH_MIDI/USB_MIDI_converter/USB_MIDI_converter.ino
@@ -35,7 +35,7 @@ USB Usb;
 USBH_MIDI  Midi(&Usb);
 
 void MIDI_poll();
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime);
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime);
 
 void setup()
 {
@@ -73,9 +73,9 @@ void MIDI_poll()
 }
 
 // Delay time (max 16383 us)
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime)
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime)
 {
-  unsigned long t3;
+  uint32_t t3;
 
   if ( t1 > t2 ) {
     t3 = (0xFFFFFFFF - t1 + t2);

--- a/examples/USBH_MIDI/USB_MIDI_converter/USB_MIDI_converter.ino
+++ b/examples/USBH_MIDI/USB_MIDI_converter/USB_MIDI_converter.ino
@@ -49,16 +49,13 @@ void setup()
 
 void loop()
 {
-  unsigned long t1;
-
   Usb.Task();
-  t1 = micros();
+  uint32_t t1 = (uint32_t)micros();
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
   {
     MIDI_poll();
   }
-  //delay(1ms)
-  doDelay(t1, micros(), 1000);
+  doDelay(t1, (uint32_t)micros(), 1000);
 }
 
 // Poll USB MIDI Controler and send to serial MIDI

--- a/examples/USBH_MIDI/USB_MIDI_converter_multi/USB_MIDI_converter_multi.ino
+++ b/examples/USBH_MIDI/USB_MIDI_converter_multi/USB_MIDI_converter_multi.ino
@@ -37,7 +37,7 @@ USBH_MIDI  Midi1(&Usb);
 USBH_MIDI  Midi2(&Usb);
 
 void MIDI_poll();
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime);
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime);
 
 void setup()
 {
@@ -81,9 +81,9 @@ void MIDI_poll()
 }
 
 // Delay time (max 16383 us)
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime)
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime)
 {
-  unsigned long t3;
+  uint32_t t3;
 
   if ( t1 > t2 ) {
     t3 = (0xFFFFFFFF - t1 + t2);

--- a/examples/USBH_MIDI/USB_MIDI_converter_multi/USB_MIDI_converter_multi.ino
+++ b/examples/USBH_MIDI/USB_MIDI_converter_multi/USB_MIDI_converter_multi.ino
@@ -51,16 +51,13 @@ void setup()
 
 void loop()
 {
-  unsigned long t1;
-
   Usb.Task();
-  t1 = micros();
+  uint32_t t1 = (uint32_t)micros();
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
   {
     MIDI_poll();
   }
-  //delay(1ms)
-  doDelay(t1, micros(), 1000);
+  doDelay(t1, (uint32_t)micros(), 1000);
 }
 
 // Poll USB MIDI Controler and send to serial MIDI

--- a/examples/USBH_MIDI/bidrectional_converter/bidrectional_converter.ino
+++ b/examples/USBH_MIDI/bidrectional_converter/bidrectional_converter.ino
@@ -70,11 +70,10 @@ void setup()
 
 void loop()
 {
-  unsigned long t1;
   uint8_t msg[4];
 
   Usb.Task();
-  t1 = micros();
+  uint32_t t1 = (uint32_t)micros();
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
   {
     MIDI_poll();
@@ -94,8 +93,7 @@ void loop()
       }
     }
   }
-  //delay(1ms)
-  doDelay(t1, micros(), 1000);
+  doDelay(t1, (uint32_t)micros(), 1000);
 }
 
 // Poll USB MIDI Controler and send to serial MIDI

--- a/examples/USBH_MIDI/bidrectional_converter/bidrectional_converter.ino
+++ b/examples/USBH_MIDI/bidrectional_converter/bidrectional_converter.ino
@@ -43,7 +43,7 @@ USB Usb;
 USBH_MIDI Midi(&Usb);
 
 void MIDI_poll();
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime);
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime);
 
 //If you want handle System Exclusive message, enable this #define otherwise comment out it.
 #define USBH_MIDI_SYSEX_ENABLE
@@ -149,9 +149,9 @@ void MIDI_poll()
 }
 
 // Delay time (max 16383 us)
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime)
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime)
 {
-  unsigned long t3;
+  uint32_t t3;
 
   if ( t1 > t2 ) {
     t3 = (0xFFFFFFFF - t1 + t2);

--- a/examples/USB_desc/USB_desc.ino
+++ b/examples/USB_desc/USB_desc.ino
@@ -60,14 +60,14 @@ void setup()
   delay( 200 );
 }
 
-byte getdevdescr( byte addr, byte &num_conf );
+uint8_t getdevdescr( uint8_t addr, uint8_t &num_conf );
 
 void PrintDescriptors(uint8_t addr)
 {
   uint8_t rcode = 0;
-  byte num_conf = 0;
+  uint8_t num_conf = 0;
 
-  rcode = getdevdescr( (byte)addr, num_conf );
+  rcode = getdevdescr( (uint8_t)addr, num_conf );
   if ( rcode )
   {
     printProgStr(Gen_Error_str);
@@ -108,10 +108,10 @@ void loop()
   }
 }
 
-byte getdevdescr( byte addr, byte &num_conf )
+uint8_t getdevdescr( uint8_t addr, uint8_t &num_conf )
 {
   USB_DEVICE_DESCRIPTOR buf;
-  byte rcode;
+  uint8_t rcode;
   rcode = Usb.getDevDescr( addr, 0, 0x12, ( uint8_t *)&buf );
   if ( rcode ) {
     return ( rcode );
@@ -195,14 +195,14 @@ void printhubdescr(uint8_t *descrptr, uint8_t addr)
   //    PrintHubPortStatus(&Usb, addr, i, 1);
 }
 
-byte getconfdescr( byte addr, byte conf )
+uint8_t getconfdescr( uint8_t addr, uint8_t conf )
 {
   uint8_t buf[ BUFSIZE ];
   uint8_t* buf_ptr = buf;
-  byte rcode;
-  byte descr_length;
-  byte descr_type;
-  unsigned int total_length;
+  uint8_t rcode;
+  uint8_t descr_length;
+  uint8_t descr_type;
+  uint16_t total_length;
   rcode = Usb.getConfDescr( addr, 0, 4, conf, buf );  //get total length
   LOBYTE( total_length ) = buf[ 2 ];
   HIBYTE( total_length ) = buf[ 3 ];
@@ -316,8 +316,8 @@ void printepdescr( uint8_t* descr_ptr )
 /*function to print unknown descriptor */
 void printunkdescr( uint8_t* descr_ptr )
 {
-  byte length = *descr_ptr;
-  byte i;
+  uint8_t length = *descr_ptr;
+  uint8_t i;
   printProgStr(Unk_Header_str);
   printProgStr(Unk_Length_str);
   print_hex( *descr_ptr, 8 );

--- a/examples/USB_desc/USB_desc.ino
+++ b/examples/USB_desc/USB_desc.ino
@@ -17,8 +17,6 @@ USB     Usb;
 //USBHub  Hub6(&Usb);
 //USBHub  Hub7(&Usb);
 
-uint32_t next_time;
-
 void PrintAllAddresses(UsbDevice *pdev)
 {
   UsbDeviceAddress adr;
@@ -60,8 +58,6 @@ void setup()
     Serial.println("OSC did not start.");
 
   delay( 200 );
-
-  next_time = millis() + 10000;
 }
 
 byte getdevdescr( byte addr, byte &num_conf );
@@ -105,13 +101,10 @@ void loop()
 
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
   {
-    //if (millis() >= next_time)
-    {
-      Usb.ForEachUsbDevice(&PrintAllDescriptors);
-      Usb.ForEachUsbDevice(&PrintAllAddresses);
+    Usb.ForEachUsbDevice(&PrintAllDescriptors);
+    Usb.ForEachUsbDevice(&PrintAllAddresses);
 
-      while ( 1 );                          //stop
-    }
+    while ( 1 );                          //stop
   }
 }
 

--- a/examples/adk/ArduinoBlinkLED/ArduinoBlinkLED.ino
+++ b/examples/adk/ArduinoBlinkLED/ArduinoBlinkLED.ino
@@ -68,8 +68,8 @@ void loop() {
       digitalWrite(LED, msg[0] ? HIGH : LOW);
     }
 
-    if ((int32_t)(millis() - timer) >= 1000) { // Send data every 1s
-      timer = millis();
+    if ((int32_t)((uint32_t)millis() - timer) >= 1000) { // Send data every 1s
+      timer = (uint32_t)millis();
       rcode = adk.SndData(sizeof(timer), (uint8_t*)&timer);
       if (rcode && rcode != hrNAK) {
         Serial.print(F("\r\nData send: "));

--- a/examples/adk/ArduinoBlinkLED/ArduinoBlinkLED.ino
+++ b/examples/adk/ArduinoBlinkLED/ArduinoBlinkLED.ino
@@ -68,7 +68,7 @@ void loop() {
       digitalWrite(LED, msg[0] ? HIGH : LOW);
     }
 
-    if (millis() - timer >= 1000) { // Send data every 1s
+    if ((int32_t)(millis() - timer) >= 1000) { // Send data every 1s
       timer = millis();
       rcode = adk.SndData(sizeof(timer), (uint8_t*)&timer);
       if (rcode && rcode != hrNAK) {

--- a/examples/adk/term_time/term_time.ino
+++ b/examples/adk/term_time/term_time.ino
@@ -41,7 +41,7 @@ void loop()
     return;
   }
 
-  ultoa( millis() / 1000, (char *)buf, 10 );
+  ultoa((uint32_t)millis() / 1000, (char *)buf, 10 );
 
   rcode = adk.SndData( strlen((char *)buf), buf );
   if (rcode && rcode != hrNAK) {

--- a/examples/ftdi/USBFTDILoopback/USBFTDILoopback.ino
+++ b/examples/ftdi/USBFTDILoopback/USBFTDILoopback.ino
@@ -39,8 +39,6 @@ USB              Usb;
 FTDIAsync        FtdiAsync;
 FTDI             Ftdi(&Usb, &FtdiAsync);
 
-uint32_t next_time;
-
 void setup()
 {
   Serial.begin( 115200 );
@@ -53,8 +51,6 @@ void setup()
       Serial.println("OSC did not start.");
 
   delay( 200 );
-
-  next_time = millis() + 5000;
 }
 
 void loop()

--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -57,7 +57,7 @@ void setup()
 
   delay( 200 );
 
-  next_time = millis() + 10000;
+  next_time = (uint32_t)millis() + 10000;
 }
 
 void PrintDescriptors(uint8_t addr)
@@ -96,7 +96,7 @@ void loop()
   Usb.Task();
 
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING ) {
-    if ((int32_t)(millis() - next_time) >= 0L) {
+    if ((int32_t)((uint32_t)millis() - next_time) >= 0L) {
       Usb.ForEachUsbDevice(&PrintAllDescriptors);
       Usb.ForEachUsbDevice(&PrintAllAddresses);
 

--- a/examples/hub_demo/hub_demo.ino
+++ b/examples/hub_demo/hub_demo.ino
@@ -96,7 +96,7 @@ void loop()
   Usb.Task();
 
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING ) {
-    if ((long)(millis() - next_time) >= 0L) {
+    if ((int32_t)(millis() - next_time) >= 0L) {
       Usb.ForEachUsbDevice(&PrintAllDescriptors);
       Usb.ForEachUsbDevice(&PrintAllAddresses);
 

--- a/examples/max_LCD/max_LCD.ino
+++ b/examples/max_LCD/max_LCD.ino
@@ -25,5 +25,5 @@ void loop() {
   // Set the cursor to column 0, line 1 (note: line 1 is the second row, since counting begins with 0):
   lcd.setCursor(0, 1);
   // Print the number of seconds since reset:
-  lcd.print(millis() / 1000);
+  lcd.print((uint32_t)millis() / 1000);
 }

--- a/examples/pl2303/pl2303_gps/pl2303_gps.ino
+++ b/examples/pl2303/pl2303_gps/pl2303_gps.ino
@@ -71,7 +71,7 @@ void loop() {
 
         if(Pl.isReady()) {
                 /* reading the GPS */
-                if((long)(millis() - read_delay) >= 0L) {
+                if((int32_t)(millis() - read_delay) >= 0L) {
                         read_delay += READ_DELAY;
                         rcode = Pl.RcvData(&rcvd, buf);
                         if(rcode && rcode != hrNAK)

--- a/examples/pl2303/pl2303_gps/pl2303_gps.ino
+++ b/examples/pl2303/pl2303_gps/pl2303_gps.ino
@@ -71,7 +71,7 @@ void loop() {
 
         if(Pl.isReady()) {
                 /* reading the GPS */
-                if((int32_t)(millis() - read_delay) >= 0L) {
+                if((int32_t)((uint32_t)millis() - read_delay) >= 0L) {
                         read_delay += READ_DELAY;
                         rcode = Pl.RcvData(&rcvd, buf);
                         if(rcode && rcode != hrNAK)

--- a/examples/pl2303/pl2303_tinygps/pl2303_tinygps.ino
+++ b/examples/pl2303/pl2303_tinygps/pl2303_tinygps.ino
@@ -130,7 +130,7 @@ void printFloat(double number, int digits)
   number += rounding;
 
   // Extract the integer part of the number and print it
-  unsigned long int_part = (unsigned long)number;
+  uint32_t int_part = (uint32_t)number;
   double remainder = number - (double)int_part;
   Serial.print(int_part);
 
@@ -150,12 +150,12 @@ void printFloat(double number, int digits)
 
 void gpsdump(TinyGPS &gps)
 {
-  long lat, lon;
+  int32_t lat, lon;
   float flat, flon;
-  unsigned long age, date, time, chars;
+  uint32_t age, date, time, chars;
   int year;
   byte month, day, hour, minute, second, hundredths;
-  unsigned short sentences, failed;
+  uint16_t sentences, failed;
 
   gps.get_position(&lat, &lon, &age);
   Serial.print("Lat/Long(10^-5 deg): "); Serial.print(lat); Serial.print(", "); Serial.print(lon);

--- a/examples/pl2303/pl2303_tinygps/pl2303_tinygps.ino
+++ b/examples/pl2303/pl2303_tinygps/pl2303_tinygps.ino
@@ -94,10 +94,10 @@ void loop()
   if( Pl.isReady()) {
 
     bool newdata = false;
-    unsigned long start = millis();
+    uint32_t start = millis();
 
     // Every 5 seconds we print an update
-    while (millis() - start < 5000) {
+    while ((int32_t)(millis() - start) < 5000) {
       if( feedgps()) {
         newdata = true;
       }

--- a/examples/pl2303/pl2303_tinygps/pl2303_tinygps.ino
+++ b/examples/pl2303/pl2303_tinygps/pl2303_tinygps.ino
@@ -94,10 +94,10 @@ void loop()
   if( Pl.isReady()) {
 
     bool newdata = false;
-    uint32_t start = millis();
+    uint32_t start = (uint32_t)millis();
 
     // Every 5 seconds we print an update
-    while ((int32_t)(millis() - start) < 5000) {
+    while ((int32_t)((uint32_t)millis() - start) < 5000) {
       if( feedgps()) {
         newdata = true;
       }

--- a/examples/pl2303/pl2303_tinygps/pl2303_tinygps.ino
+++ b/examples/pl2303/pl2303_tinygps/pl2303_tinygps.ino
@@ -64,7 +64,7 @@ TinyGPS gps;
 
 void gpsdump(TinyGPS &gps);
 bool feedgps();
-void printFloat(double f, int digits = 2);
+void printFloat(double f, int16_t digits = 2);
 
 void setup()
 {
@@ -113,7 +113,7 @@ void loop()
   }//if( Usb.getUsbTaskState() == USB_STATE_RUNNING...
 }
 
-void printFloat(double number, int digits)
+void printFloat(double number, int16_t digits)
 {
   // Handle negative numbers
   if (number < 0.0)
@@ -153,8 +153,8 @@ void gpsdump(TinyGPS &gps)
   int32_t lat, lon;
   float flat, flon;
   uint32_t age, date, time, chars;
-  int year;
-  byte month, day, hour, minute, second, hundredths;
+  int16_t year;
+  uint8_t month, day, hour, minute, second, hundredths;
   uint16_t sentences, failed;
 
   gps.get_position(&lat, &lon, &age);
@@ -175,7 +175,7 @@ void gpsdump(TinyGPS &gps)
 
   feedgps();
 
-  gps.crack_datetime(&year, &month, &day, &hour, &minute, &second, &hundredths, &age);
+  gps.crack_datetime((int*)&year, &month, &day, &hour, &minute, &second, &hundredths, &age);
   Serial.print("Date: "); Serial.print(static_cast<int>(month)); Serial.print("/"); Serial.print(static_cast<int>(day)); Serial.print("/"); Serial.print(year);
   Serial.print("  Time: "); Serial.print(static_cast<int>(hour)); Serial.print(":"); Serial.print(static_cast<int>(minute)); Serial.print(":"); Serial.print(static_cast<int>(second)); Serial.print("."); Serial.print(static_cast<int>(hundredths));
   Serial.print("  Fix age: ");  Serial.print(age); Serial.println("ms.");
@@ -189,7 +189,7 @@ void gpsdump(TinyGPS &gps)
 
   feedgps();
 
-  gps.stats(&chars, &sentences, &failed);
+  gps.stats(&chars, (unsigned short*)&sentences, (unsigned short*)&failed);
   Serial.print("Stats: characters: "); Serial.print(chars); Serial.print(" sentences: "); Serial.print(sentences); Serial.print(" failed checksum: "); Serial.println(failed);
 }
 

--- a/examples/testusbhostFAT/testusbhostFAT.ino
+++ b/examples/testusbhostFAT/testusbhostFAT.ino
@@ -284,7 +284,7 @@ void setup() {
         analogWrite(LED_BUILTIN, 0);
         delay(500);
 
-        LEDnext_time = millis() + 1;
+        LEDnext_time = (uint32_t)millis() + 1;
 #if EXT_RAM
         printf_P(PSTR("Total EXT RAM banks %i\r\n"), xmem::getTotalBanks());
 #endif
@@ -321,10 +321,10 @@ void setup() {
         TIMSK3 |= (1 << OCIE1A);
         sei();
 
-        HEAPnext_time = millis() + 10000;
+        HEAPnext_time = (uint32_t)millis() + 10000;
 #endif
 #if defined(__AVR__)
-        HEAPnext_time = millis() + 10000;
+        HEAPnext_time = (uint32_t)millis() + 10000;
 #endif
 }
 
@@ -371,8 +371,8 @@ void serialEvent() {
 // ALL teensy versions LACK PWM ON LED
 
 ISR(TIMER3_COMPA_vect) {
-        if((int32_t)(millis() - LEDnext_time) >= 0L) {
-                LEDnext_time = millis() + 30;
+        if((int32_t)((uint32_t)millis() - LEDnext_time) >= 0L) {
+                LEDnext_time = (uint32_t)millis() + 30;
 
                 // set the brightness of LED
                 analogWrite(LED_BUILTIN, brightness);
@@ -407,11 +407,11 @@ void loop() {
 
 #if defined(__AVR__)
         // Print a heap status report about every 10 seconds.
-        if((int32_t)(millis() - HEAPnext_time) >= 0L) {
+        if((int32_t)((uint32_t)millis() - HEAPnext_time) >= 0L) {
                 if(UsbDEBUGlvl > 0x50) {
                         printf_P(PSTR("Available heap: %u Bytes\r\n"), freeHeap());
                 }
-                HEAPnext_time = millis() + 10000;
+                HEAPnext_time = (uint32_t)millis() + 10000;
         }
         TCCR3B = 0;
 #endif
@@ -421,7 +421,7 @@ void loop() {
 #endif
         // Horrid! This sort of thing really belongs in an ISR, not here!
         // We also will be needing to test each hub port, we don't do this yet!
-        if(!change && !usbon && (int32_t)(millis() - usbon_time) >= 0L) {
+        if(!change && !usbon && (int32_t)((uint32_t)millis() - usbon_time) >= 0L) {
                 change = true;
                 usbon = true;
         }
@@ -433,7 +433,7 @@ void loop() {
                         printf_P(PSTR("VBUS on\r\n"));
                 } else {
                         Usb.vbusPower(vbus_off);
-                        usbon_time = millis() + 2000;
+                        usbon_time = (uint32_t)millis() + 2000;
                 }
         }
         Usb.Task();
@@ -700,27 +700,27 @@ out:
                                 if(rc) goto failed;
                                 for(bw = 0; bw < mbxs; bw++) My_Buff_x[bw] = bw & 0xff;
                                 fflush(stdout);
-                                start = millis();
-                                while(start == millis());
+                                start = (uint32_t)millis();
+                                while(start == (uint32_t)millis());
                                 for(ii = 10485760LU / mbxs; ii > 0LU; ii--) {
                                         rc = f_write(&My_File_Object_x, My_Buff_x, mbxs, &bw);
                                         if(rc || !bw) goto failed;
                                 }
                                 rc = f_close(&My_File_Object_x);
                                 if(rc) goto failed;
-                                end = millis();
+                                end = (uint32_t)millis();
                                 wt = (end - start) - 1;
                                 printf_P(PSTR("Time to write 10485760 bytes: %lu ms (%lu sec) \r\n"), wt, (500 + wt) / 1000UL);
                                 rc = f_open(&My_File_Object_x, "0:/10MB.bin", FA_READ);
                                 fflush(stdout);
-                                start = millis();
-                                while(start == millis());
+                                start = (uint32_t)millis();
+                                while(start == (uint32_t)millis());
                                 if(rc) goto failed;
                                 for(;;) {
                                         rc = f_read(&My_File_Object_x, My_Buff_x, mbxs, &bw); /* Read a chunk of file */
                                         if(rc || !bw) break; /* Error or end of file */
                                 }
-                                end = millis();
+                                end = (uint32_t)millis();
                                 if(rc) goto failed;
                                 rc = f_close(&My_File_Object_x);
                                 if(rc) goto failed;

--- a/examples/testusbhostFAT/testusbhostFAT.ino
+++ b/examples/testusbhostFAT/testusbhostFAT.ino
@@ -371,7 +371,7 @@ void serialEvent() {
 // ALL teensy versions LACK PWM ON LED
 
 ISR(TIMER3_COMPA_vect) {
-        if((long)(millis() - LEDnext_time) >= 0L) {
+        if((int32_t)(millis() - LEDnext_time) >= 0L) {
                 LEDnext_time = millis() + 30;
 
                 // set the brightness of LED
@@ -407,7 +407,7 @@ void loop() {
 
 #if defined(__AVR__)
         // Print a heap status report about every 10 seconds.
-        if((long)(millis() - HEAPnext_time) >= 0L) {
+        if((int32_t)(millis() - HEAPnext_time) >= 0L) {
                 if(UsbDEBUGlvl > 0x50) {
                         printf_P(PSTR("Available heap: %u Bytes\r\n"), freeHeap());
                 }
@@ -421,7 +421,7 @@ void loop() {
 #endif
         // Horrid! This sort of thing really belongs in an ISR, not here!
         // We also will be needing to test each hub port, we don't do this yet!
-        if(!change && !usbon && (long)(millis() - usbon_time) >= 0L) {
+        if(!change && !usbon && (int32_t)(millis() - usbon_time) >= 0L) {
                 change = true;
                 usbon = true;
         }

--- a/hidboot.h
+++ b/hidboot.h
@@ -578,7 +578,7 @@ template <const uint8_t BOOT_PROTOCOL>
 uint8_t HIDBoot<BOOT_PROTOCOL>::Poll() {
         uint8_t rcode = 0;
 
-        if(bPollEnable && ((long)(millis() - qNextPollTime) >= 0L)) {
+        if(bPollEnable && ((int32_t)(millis() - qNextPollTime) >= 0L)) {
 
                 // To-do: optimize manually, using the for loop only if needed.
                 for(int i = 0; i < epMUL(BOOT_PROTOCOL); i++) {

--- a/hidboot.h
+++ b/hidboot.h
@@ -578,7 +578,7 @@ template <const uint8_t BOOT_PROTOCOL>
 uint8_t HIDBoot<BOOT_PROTOCOL>::Poll() {
         uint8_t rcode = 0;
 
-        if(bPollEnable && ((int32_t)(millis() - qNextPollTime) >= 0L)) {
+        if(bPollEnable && ((int32_t)((uint32_t)millis() - qNextPollTime) >= 0L)) {
 
                 // To-do: optimize manually, using the for loop only if needed.
                 for(int i = 0; i < epMUL(BOOT_PROTOCOL); i++) {
@@ -619,7 +619,7 @@ uint8_t HIDBoot<BOOT_PROTOCOL>::Poll() {
                         }
 
                 }
-                qNextPollTime = millis() + bInterval;
+                qNextPollTime = (uint32_t)millis() + bInterval;
         }
         return rcode;
 }

--- a/hidcomposite.cpp
+++ b/hidcomposite.cpp
@@ -360,8 +360,8 @@ uint8_t HIDComposite::Poll() {
         if(!bPollEnable)
                 return 0;
 
-        if((int32_t)(millis() - qNextPollTime) >= 0L) {
-                qNextPollTime = millis() + pollInterval;
+        if((int32_t)((uint32_t)millis() - qNextPollTime) >= 0L) {
+                qNextPollTime = (uint32_t)millis() + pollInterval;
 
                 uint8_t buf[constBuffLen];
 

--- a/hidcomposite.cpp
+++ b/hidcomposite.cpp
@@ -360,7 +360,7 @@ uint8_t HIDComposite::Poll() {
         if(!bPollEnable)
                 return 0;
 
-        if((long)(millis() - qNextPollTime) >= 0L) {
+        if((int32_t)(millis() - qNextPollTime) >= 0L) {
                 qNextPollTime = millis() + pollInterval;
 
                 uint8_t buf[constBuffLen];

--- a/hiduniversal.cpp
+++ b/hiduniversal.cpp
@@ -372,8 +372,8 @@ uint8_t HIDUniversal::Poll() {
         if(!bPollEnable)
                 return 0;
 
-        if((int32_t)(millis() - qNextPollTime) >= 0L) {
-                qNextPollTime = millis() + pollInterval;
+        if((int32_t)((uint32_t)millis() - qNextPollTime) >= 0L) {
+                qNextPollTime = (uint32_t)millis() + pollInterval;
 
                 uint8_t buf[constBuffLen];
 

--- a/hiduniversal.cpp
+++ b/hiduniversal.cpp
@@ -372,7 +372,7 @@ uint8_t HIDUniversal::Poll() {
         if(!bPollEnable)
                 return 0;
 
-        if((long)(millis() - qNextPollTime) >= 0L) {
+        if((int32_t)(millis() - qNextPollTime) >= 0L) {
                 qNextPollTime = millis() + pollInterval;
 
                 uint8_t buf[constBuffLen];

--- a/masstorage.cpp
+++ b/masstorage.cpp
@@ -659,7 +659,7 @@ void BulkOnly::CheckMedia() {
         }
         printf("\r\n");
 #endif
-        qNextPollTime = millis() + 2000;
+        qNextPollTime = (uint32_t)millis() + 2000;
 }
 
 /**
@@ -673,7 +673,7 @@ uint8_t BulkOnly::Poll() {
         if(!bPollEnable)
                 return 0;
 
-        if((int32_t)(millis() - qNextPollTime) >= 0L) {
+        if((int32_t)((uint32_t)millis() - qNextPollTime) >= 0L) {
                 CheckMedia();
         }
         //rcode = 0;

--- a/masstorage.cpp
+++ b/masstorage.cpp
@@ -673,7 +673,7 @@ uint8_t BulkOnly::Poll() {
         if(!bPollEnable)
                 return 0;
 
-        if((long)(millis() - qNextPollTime) >= 0L) {
+        if((int32_t)(millis() - qNextPollTime) >= 0L) {
                 CheckMedia();
         }
         //rcode = 0;

--- a/usbh_midi.cpp
+++ b/usbh_midi.cpp
@@ -243,9 +243,9 @@ void USBH_MIDI::parseConfigDescr( uint8_t addr, uint8_t conf )
         uint8_t rcode;
         uint8_t descr_length;
         uint8_t descr_type;
-        unsigned int total_length;
+        uint16_t total_length;
         USB_ENDPOINT_DESCRIPTOR *epDesc;
-        boolean isMidi = false;
+        bool isMidi = false;
 
         // get configuration descriptor (get descriptor size only)
         rcode = pUsb->getConfDescr( addr, 0, 4, conf, buf );
@@ -486,9 +486,9 @@ uint8_t USBH_MIDI::lookupMsgSize(uint8_t midiMsg)
 }
 
 /* SysEx data size counter */
-unsigned int USBH_MIDI::countSysExDataSize(uint8_t *dataptr)
+uint16_t USBH_MIDI::countSysExDataSize(uint8_t *dataptr)
 {
-        unsigned int c = 1;
+        uint16_t c = 1;
 
         if( *dataptr != 0xf0 ){ //not SysEx
                 return 0;
@@ -510,12 +510,12 @@ unsigned int USBH_MIDI::countSysExDataSize(uint8_t *dataptr)
 }
 
 /* Send SysEx message to MIDI device */
-uint8_t USBH_MIDI::SendSysEx(uint8_t *dataptr, unsigned int datasize, uint8_t nCable)
+uint8_t USBH_MIDI::SendSysEx(uint8_t *dataptr, uint16_t datasize, uint8_t nCable)
 {
         uint8_t buf[64];
         uint8_t rc;
-        unsigned int n = datasize;
-        unsigned int pktSize = (n*10/3+7)/10*4;   //Calculate total USB MIDI packet size
+        uint16_t n = datasize;
+        uint16_t pktSize = (n*10/3+7)/10*4;   //Calculate total USB MIDI packet size
         uint8_t wptr = 0;
         uint8_t maxpkt = epInfo[epDataInIndex].maxPktSize;
 

--- a/usbh_midi.h
+++ b/usbh_midi.h
@@ -58,7 +58,7 @@ protected:
         uint8_t readPtr;
 
         void parseConfigDescr(uint8_t addr, uint8_t conf);
-        unsigned int countSysExDataSize(uint8_t *dataptr);
+        uint16_t countSysExDataSize(uint8_t *dataptr);
 #ifdef DEBUG_USB_HOST
         void PrintEndpointDescriptor( const USB_ENDPOINT_DESCRIPTOR* ep_ptr );
 #endif
@@ -70,7 +70,7 @@ public:
         uint8_t RecvData(uint8_t *outBuf);
         uint8_t SendData(uint8_t *dataptr, uint8_t nCable=0);
         uint8_t lookupMsgSize(uint8_t midiMsg);
-        uint8_t SendSysEx(uint8_t *dataptr, unsigned int datasize, uint8_t nCable=0);
+        uint8_t SendSysEx(uint8_t *dataptr, uint16_t datasize, uint8_t nCable=0);
         uint8_t SendRawData(uint16_t bytes_send, uint8_t *dataptr);
         // backward compatibility functions
         inline uint8_t RcvData(uint16_t *bytes_rcvd, uint8_t *dataptr){ return RecvData(bytes_rcvd, dataptr); };

--- a/usbhub.cpp
+++ b/usbhub.cpp
@@ -232,9 +232,9 @@ uint8_t USBHub::Poll() {
         if(!bPollEnable)
                 return 0;
 
-        if(((int32_t)(millis() - qNextPollTime) >= 0L)) {
+        if(((int32_t)((uint32_t)millis() - qNextPollTime) >= 0L)) {
                 rcode = CheckHubStatus();
-                qNextPollTime = millis() + 100;
+                qNextPollTime = (uint32_t)millis() + 100;
         }
         return rcode;
 }

--- a/usbhub.cpp
+++ b/usbhub.cpp
@@ -232,7 +232,7 @@ uint8_t USBHub::Poll() {
         if(!bPollEnable)
                 return 0;
 
-        if(((long)(millis() - qNextPollTime) >= 0L)) {
+        if(((int32_t)(millis() - qNextPollTime) >= 0L)) {
                 rcode = CheckHubStatus();
                 qNextPollTime = millis() + 100;
         }


### PR DESCRIPTION
* Fix millis() and micros() rollover bug
* Explicit cast millis() and micros() to uint32_t, as it is uint64_t on the Arduino 101
* Use fixed width integer types, so it is not architecture dependent

See: https://github.com/felis/USB_Host_Shield_2.0/issues/285#issuecomment-279200128

@YuuichiAkagawa and @mattomatto can you guys test this?