### PR TITLE
Update MIDI driver v0.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ env:
     - PLATFORMIO_CI_SRC=examples/PSBuzz
     # - PLATFORMIO_CI_SRC=examples/testusbhostFAT
     - PLATFORMIO_CI_SRC=examples/USB_desc
-    - PLATFORMIO_CI_SRC=examples/USBH_MIDI/bidrectional_converter
+    - PLATFORMIO_CI_SRC=examples/USBH_MIDI/bidirectional_converter
     - PLATFORMIO_CI_SRC=examples/USBH_MIDI/eVY1_sample
     - PLATFORMIO_CI_SRC=examples/USBH_MIDI/USB_MIDI_converter
     - PLATFORMIO_CI_SRC=examples/USBH_MIDI/USB_MIDI_converter_multi

--- a/examples/USBH_MIDI/USBH_MIDI_dump/USBH_MIDI_dump.ino
+++ b/examples/USBH_MIDI/USBH_MIDI_dump/USBH_MIDI_dump.ino
@@ -1,7 +1,7 @@
 /*
  *******************************************************************************
  * USB-MIDI dump utility
- * Copyright (C) 2013-2016 Yuuichi Akagawa
+ * Copyright (C) 2013-2017 Yuuichi Akagawa
  *
  * for use with USB Host Shield 2.0 from Circuitsathome.com
  * https://github.com/felis/USB_Host_Shield_2.0
@@ -24,7 +24,7 @@ USB Usb;
 USBH_MIDI  Midi(&Usb);
 
 void MIDI_poll();
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime);
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime);
 
 boolean bFirst;
 uint16_t pid, vid;
@@ -46,13 +46,13 @@ void loop()
   //unsigned long t1;
 
   Usb.Task();
-  //t1 = micros();
+  //uint32_t t1 = (uint32_t)micros();
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
   {
     MIDI_poll();
   }
   //delay(1ms)
-  //doDelay(t1, micros(), 1000);
+  //doDelay(t1, (uint32_t)micros(), 1000);
 }
 
 // Poll USB MIDI Controler and send to serial MIDI
@@ -69,11 +69,7 @@ void MIDI_poll()
     pid = Midi.pid;
   }
   if (Midi.RecvData( &rcvd,  bufMidi) == 0 ) {
-#ifdef __ARDUINO_ARC__
-    sprintf(buf, "%016llX: ", millis()); // millis() is 64-bits on the Arduino/Genuino 101
-#else
-    sprintf(buf, "%08lX: ", millis());
-#endif
+    sprintf(buf, "%08lX: ", (uint32_t)millis());
     Serial.print(buf);
     Serial.print(rcvd);
     Serial.print(':');
@@ -86,9 +82,9 @@ void MIDI_poll()
 }
 
 // Delay time (max 16383 us)
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime)
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime)
 {
-  unsigned long t3;
+  uint32_t t3;
 
   if ( t1 > t2 ) {
     t3 = (0xFFFFFFFF - t1 + t2);

--- a/examples/USBH_MIDI/USB_MIDI_converter/USB_MIDI_converter.ino
+++ b/examples/USBH_MIDI/USB_MIDI_converter/USB_MIDI_converter.ino
@@ -1,7 +1,7 @@
 /*
  *******************************************************************************
  * USB-MIDI to Legacy Serial MIDI converter
- * Copyright (C) 2012-2016 Yuuichi Akagawa
+ * Copyright (C) 2012-2017 Yuuichi Akagawa
  *
  * Idea from LPK25 USB-MIDI to Serial MIDI converter
  *   by Collin Cunningham - makezine.com, narbotic.com
@@ -35,7 +35,7 @@ USB Usb;
 USBH_MIDI  Midi(&Usb);
 
 void MIDI_poll();
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime);
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime);
 
 void setup()
 {
@@ -49,16 +49,14 @@ void setup()
 
 void loop()
 {
-  unsigned long t1;
-
   Usb.Task();
-  t1 = micros();
+  uint32_t t1 = (uint32_t)micros();
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
   {
     MIDI_poll();
   }
   //delay(1ms)
-  doDelay(t1, micros(), 1000);
+  doDelay(t1, (uint32_t)micros(), 1000);
 }
 
 // Poll USB MIDI Controler and send to serial MIDI
@@ -76,9 +74,9 @@ void MIDI_poll()
 }
 
 // Delay time (max 16383 us)
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime)
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime)
 {
-  unsigned long t3;
+  uint32_t t3;
 
   if ( t1 > t2 ) {
     t3 = (0xFFFFFFFF - t1 + t2);

--- a/examples/USBH_MIDI/USB_MIDI_converter_multi/USB_MIDI_converter_multi.ino
+++ b/examples/USBH_MIDI/USB_MIDI_converter_multi/USB_MIDI_converter_multi.ino
@@ -1,7 +1,7 @@
 /*
  *******************************************************************************
  * USB-MIDI to Legacy Serial MIDI converter
- * Copyright (C) 2012-2016 Yuuichi Akagawa
+ * Copyright (C) 2012-2017 Yuuichi Akagawa
  *
  * Idea from LPK25 USB-MIDI to Serial MIDI converter
  *   by Collin Cunningham - makezine.com, narbotic.com
@@ -37,7 +37,7 @@ USBH_MIDI  Midi1(&Usb);
 USBH_MIDI  Midi2(&Usb);
 
 void MIDI_poll();
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime);
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime);
 
 void setup()
 {
@@ -51,16 +51,14 @@ void setup()
 
 void loop()
 {
-  unsigned long t1;
-
   Usb.Task();
-  t1 = micros();
+  uint32_t t1 = (uint32_t)micros();
   if ( Usb.getUsbTaskState() == USB_STATE_RUNNING )
   {
     MIDI_poll();
   }
   //delay(1ms)
-  doDelay(t1, micros(), 1000);
+  doDelay(t1, (uint32_t)micros(), 1000);
 }
 
 // Poll USB MIDI Controler and send to serial MIDI
@@ -84,9 +82,9 @@ void MIDI_poll()
 }
 
 // Delay time (max 16383 us)
-void doDelay(unsigned long t1, unsigned long t2, unsigned long delayTime)
+void doDelay(uint32_t t1, uint32_t t2, uint32_t delayTime)
 {
-  unsigned long t3;
+  uint32_t t3;
 
   if ( t1 > t2 ) {
     t3 = (0xFFFFFFFF - t1 + t2);


### PR DESCRIPTION
Update MIDI driver and examples.
## ChangeLog

2017.02.26 (0.3.2)
- Improve reconnect stability.
- Fix for MIDI out only device support.
- Update SysEx code
- Remove MidiSysEx class
- Add new example USB_MIDI_converter_wSysEx
- Fix typo: the example name was corrected from 'bidrectional_converter' to 'bidirectional_converter'.
- Fix Arduino/Genuino 101 compatibility
