### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -82,9 +82,9 @@ getX	KEYWORD2
 getY	KEYWORD2
 getTouchCounter	KEYWORD2
 
-getUsbStatus    KEYWORD2
-getAudioStatus  KEYWORD2
-getMicStatus    KEYWORD2
+getUsbStatus	KEYWORD2
+getAudioStatus	KEYWORD2
+getMicStatus	KEYWORD2
 
 ####################################################
 # Constants and enums (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords