### PR TITLE
Add SS, INT pins for Sanguino.

### DIFF
--- a/UsbCore.h
+++ b/UsbCore.h
@@ -50,6 +50,8 @@ typedef MAX3421e<P3, P2> MAX3421E; // The Intel Galileo supports much faster rea
 typedef MAX3421e<P15, P5> MAX3421E; // ESP8266 boards
 #elif defined(ESP32)
 typedef MAX3421e<P5, P17> MAX3421E; // ESP32 boards
+#elif (defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284P__))
+typedef MAX3421e<Pb4, Pb3> MAX3421E; // Sanguino
 #else
 typedef MAX3421e<P10, P9> MAX3421E; // Official Arduinos (UNO, Duemilanove, Mega, 2560, Leonardo, Due etc.), Intel Edison, Intel Galileo 2 or Teensy 2.0 and 3.x
 #endif


### PR DESCRIPTION
Tested with USB Shield: DuinoFun UHS mini v2.0 (Aug. 16, 2014)