### PR TITLE
Fix some bugs

### DIFF
--- a/Usb.cpp
+++ b/Usb.cpp
@@ -172,8 +172,6 @@ uint8_t USB::ctrlReq(uint8_t addr, uint8_t ep, uint8_t bmReqType, uint8_t bReque
 
                                 rcode = InTransfer(pep, nak_limit, &read, dataptr);
                                 if(rcode == hrTOGERR) {
-                                        // yes, we flip it wrong here so that next time it is actually correct!
-                                        pep->bmRcvToggle = (regRd(rHRSL) & bmSNDTOGRD) ? 0 : 1;
                                         continue;
                                 }
 
@@ -239,9 +237,6 @@ uint8_t USB::InTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t *nbytesptr, ui
 #endif
                 rcode = dispatchPkt(tokIN, pep->epAddr, nak_limit); //IN packet to EP-'endpoint'. Function takes care of NAKS.
                 if(rcode == hrTOGERR) {
-                        // yes, we flip it wrong here so that next time it is actually correct!
-                        pep->bmRcvToggle = (regRd(rHRSL) & bmRCVTOGRD) ? 0 : 1;
-                        regWr(rHCTL, (pep->bmRcvToggle) ? bmRCVTOG1 : bmRCVTOG0); //set toggle value
                         continue;
                 }
                 if(rcode) {
@@ -363,9 +358,6 @@ uint8_t USB::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8
                                         //return ( rcode);
                                         break;
                                 case hrTOGERR:
-                                        // yes, we flip it wrong here so that next time it is actually correct!
-                                        pep->bmSndToggle = (regRd(rHRSL) & bmSNDTOGRD) ? 0 : 1;
-                                        regWr(rHCTL, (pep->bmSndToggle) ? bmSNDTOG1 : bmSNDTOG0); //set toggle value
                                         break;
                                 default:
                                         goto breakout;

--- a/hidescriptorparser.cpp
+++ b/hidescriptorparser.cpp
@@ -1510,18 +1510,11 @@ uint8_t ReportDescParser2::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
 
 void ReportDescParser2::OnInputItem(uint8_t itm) {
         uint8_t byte_offset = (totalSize >> 3); // calculate offset to the next unhandled byte i = (int)(totalCount / 8);
-        uint32_t tmp = (byte_offset << 3);
-        uint8_t bit_offset = totalSize - tmp; // number of bits in the current byte already handled
         uint8_t *p = pBuf + byte_offset; // current byte pointer
-
-        if(bit_offset)
-                *p >>= bit_offset;
 
         uint8_t usage = useMin;
 
         bool print_usemin_usemax = ((useMin < useMax) && ((itm & 3) == 2) && pfUsage) ? true : false;
-
-        uint8_t bits_of_byte = 8;
 
         // for each field in field array defined by rptCount
         for(uint8_t field = 0; field < rptCount; field++, usage++) {
@@ -1543,30 +1536,27 @@ void ReportDescParser2::OnInputItem(uint8_t itm) {
                 // bits_to_copy         - number of bits to copy to result buffer
 
                 // for each bit in a field
-                for(uint8_t bits_left = rptSize, bits_to_copy = 0; bits_left;
+                for(uint8_t bits_left = rptSize, bits_to_copy = 0, index = 0; bits_left;
                         bits_left -= bits_to_copy) {
-                        bits_to_copy = (bits_left > bits_of_byte) ? bits_of_byte : bits_left;
-
-                        result.dwResult <<= bits_to_copy; // Result buffer is shifted by the number of bits to be copied into it
-
                         uint8_t val = *p;
-
                         val >>= (8 - bits_of_byte); // Shift by the number of bits already processed
 
-                        mask = 0;
+                        bits_to_copy = (bits_left > bits_of_byte) ? bits_of_byte : bits_left;
 
+                        mask = 0;
                         for(uint8_t j = bits_to_copy; j; j--) {
                                 mask <<= 1;
                                 mask |= 1;
                         }
 
-                        result.bResult[0] = (result.bResult[0] | (val & mask));
+                        result.bResult[index] = (result.bResult[index] | (val & mask));
 
                         bits_of_byte -= bits_to_copy;
 
                         if(bits_of_byte < 1) {
                                 bits_of_byte = 8;
                                 p++;
+                                index++;
                         }
                 }
                 PrintByteValue(result.dwResult);

--- a/hidescriptorparser.cpp
+++ b/hidescriptorparser.cpp
@@ -990,12 +990,14 @@ const char * const ReportDescParserBase::medInstrTitles4[] PROGMEM = {
         pstrUsageSoftControlAdjust
 };
 
-void ReportDescParserBase::Parse(const uint16_t len, const uint8_t *pbuf, const uint16_t &offset __attribute__((unused))) {
+void ReportDescParserBase::Parse(const uint16_t len, const uint8_t *pbuf, const uint16_t &offset) {
         uint16_t cntdn = (uint16_t)len;
         uint8_t *p = (uint8_t*)pbuf;
 
-
-        totalSize = 0;
+        // If offset is set, parsing is in progress.
+        if(offset == 0) {
+                totalSize = 0;
+        }
 
         while(cntdn) {
                 //USB_HOST_SERIAL.println("");
@@ -1198,8 +1200,6 @@ uint8_t ReportDescParserBase::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
                                 case (TYPE_MAIN | TAG_MAIN_OUTPUT):
                                 case (TYPE_MAIN | TAG_MAIN_FEATURE):
                                         totalSize += (uint16_t)rptSize * (uint16_t)rptCount;
-                                        rptSize = 0;
-                                        rptCount = 0;
                                         E_Notify(PSTR("("), 0x80);
                                         PrintBin<uint8_t > (data, 0x80);
                                         E_Notify(PSTR(")"), 0x80);
@@ -1490,8 +1490,6 @@ uint8_t ReportDescParser2::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
                                         break;
                                 case (TYPE_MAIN | TAG_MAIN_OUTPUT):
                                 case (TYPE_MAIN | TAG_MAIN_FEATURE):
-                                        rptSize = 0;
-                                        rptCount = 0;
                                         useMin = 0;
                                         useMax = 0;
                                         break;
@@ -1500,8 +1498,6 @@ uint8_t ReportDescParser2::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
 
                                         totalSize += (uint16_t)rptSize * (uint16_t)rptCount;
 
-                                        rptSize = 0;
-                                        rptCount = 0;
                                         useMin = 0;
                                         useMax = 0;
                                         break;

--- a/hidescriptorparser.h
+++ b/hidescriptorparser.h
@@ -156,6 +156,8 @@ class ReportDescParser2 : public ReportDescParserBase {
         uint8_t *pBuf; // Report buffer pointer
         uint8_t bLen; // Report length
 
+        uint8_t bits_of_byte;
+
 protected:
         // Method should be defined here if virtual.
         virtual uint8_t ParseItem(uint8_t **pp, uint16_t *pcntdn);
@@ -163,7 +165,7 @@ protected:
 public:
 
         ReportDescParser2(uint16_t len, uint8_t *pbuf) :
-        ReportDescParserBase(), rptId(0), useMin(0), useMax(0), fieldCount(0), pBuf(pbuf), bLen(len) {
+        ReportDescParserBase(), rptId(0), useMin(0), useMax(0), fieldCount(0), pBuf(pbuf), bLen(len), bits_of_byte(8) {
         };
 };
 


### PR DESCRIPTION
1. Do not reset Global Items rptSize and rptCount on Main Items
In Report Descriptor parsing, Global Item will remain after the Main Item.

2. Do not flip toggle value on Toggle Error
In [MAX3421E Programming Guide ](https://pdfserv.maximintegrated.com/en/an/AN3785.pdf) p13 

> By ACK-ing the transfer and not updating its own toggle bit, the SIE causes the peripheral to complement its toggle bit, thus forcing the data toggle mechanism back into sync. 

In short, there is no need to flip on a toggle error.
With this fix my Logitech Gamepad F310 is now working.

3. Fix reading of data with offset
Reading of multiple bytes of data probably got bugged, so I fixed it.