### PR TITLE
Fix corruption. NEVER use SPI method transfer on a pointer.

### DIFF
--- a/usbhost.h
+++ b/usbhost.h
@@ -228,21 +228,15 @@ uint8_t* MAX3421e< SPI_SS, INTR >::bytesWr(uint8_t reg, uint8_t nbytes, uint8_t*
         spi4teensy3::send(reg | 0x02);
         spi4teensy3::send(data_p, nbytes);
         data_p += nbytes;
-#elif defined(SPI_HAS_TRANSACTION) && !defined(ESP8266) && !defined(ESP32)
-        USB_SPI.transfer(reg | 0x02);
-        USB_SPI.transfer(data_p, nbytes);
-        data_p += nbytes;
-#elif defined(__ARDUINO_X86__)
-        USB_SPI.transfer(reg | 0x02);
-        USB_SPI.transferBuffer(data_p, NULL, nbytes);
-        data_p += nbytes;
 #elif defined(STM32F4)
         uint8_t data = reg | 0x02;
         HAL_SPI_Transmit(&SPI_Handle, &data, 1, HAL_MAX_DELAY);
         HAL_SPI_Transmit(&SPI_Handle, data_p, nbytes, HAL_MAX_DELAY);
         data_p += nbytes;
-#elif !defined(SPDR) // ESP8266, ESP32
+#elif !defined(__AVR__) || !defined(SPDR)
+#if defined(ESP8266) || defined(ESP32)
         yield();
+#endif
         USB_SPI.transfer(reg | 0x02);
         while(nbytes) {
                 USB_SPI.transfer(*data_p);


### PR DESCRIPTION
Should fix the problems.
Also removes duplicate code.
