### PR TITLE
Remove bufffers comparing functionality

### DIFF
--- a/hiduniversal.cpp
+++ b/hiduniversal.cpp
@@ -392,12 +392,6 @@ uint8_t HIDUniversal::Poll() {
                         if(read > constBuffLen)
                                 read = constBuffLen;
 
-                        bool identical = BuffersIdentical(read, buf, prevBuf);
-
-                        SaveBuffer(read, buf, prevBuf);
-
-                        if(identical)
-                                return 0;
 #if 0
                         Notify(PSTR("\r\nBuf: "), 0x80);
 


### PR DESCRIPTION
I am using class derived from HIDUniversal for reading reports from weather station Oregon Scientific WMRS200, and polling of reports (method Poll) removed any sequence of 2 or more identical bytes, e.g. instead of valid sequence
FF FF 00 42 00 B8 00 2C 3C 00 00 00 62 01 (1)
i get
FF 00 42 00 B8 00 2C 3C 00 62 01, because there are two FF (FF FF -> FF) and three 00 (00 00 00 -> 00) in a row.
There is no need to compare previous buffer with current buffer, as they can be identical and still this should not be ignored.
My sequences are built (concatenated) from smaller sequences, where first byte in smaller sequence is the number of bytes following first byte. Usually the main sequence is concatenated from sequences of just 1 byte of valid data, e.g. 01 FF, 01 FF, 01 00, 01 42 etc. for sequence (1). But current code is filtering out the second smaller sequences 01 FF and result is only one FF in main (concatenated) sequence, instead of FF FF. Similarly for three consequent sequences of 01 00, I should obtain 00 00 00 in concatenated sequence, but get just 00.
Filtering is not needed, because data are obtained using inTransfer, which should remove already read data.
I consider this as a BUG.