### PR TITLE
Add a ParseBTHIDControlData virtual method similar to ParseBTHIDData,

### DIFF
--- a/BTHID.cpp
+++ b/BTHID.cpp
@@ -215,6 +215,10 @@ void BTHID::ACLData(uint8_t* l2capinbuf) {
                                 Notify(PSTR(" "), 0x80);
                         }
 #endif
+                        if(l2capinbuf[8] == 0xA3) {
+                                uint16_t length = ((uint16_t)l2capinbuf[5] << 8 | l2capinbuf[4]);
+                                ParseBTHIDControlData((uint8_t)(length - 1), &l2capinbuf[9]);
+                        }
                 }
 #ifdef EXTRADEBUG
                 else {

--- a/BTHID.h
+++ b/BTHID.h
@@ -125,6 +125,13 @@ protected:
         virtual void ParseBTHIDData(uint8_t len __attribute__((unused)), uint8_t *buf __attribute__((unused))) {
                 return;
         };
+        /**
+         * Same as ParseBTHIDData for reports that are sent through the
+         * interrupt pipe (in response to a GET_REPORT).
+         */
+        virtual void ParseBTHIDControlData(uint8_t len __attribute__((unused)), uint8_t *buf __attribute__((unused))) {
+                return;
+        }
         /** Called when a device is connected */
         virtual void OnInitBTHID() {
                 return;


### PR DESCRIPTION
for reports that are sent through the control pipe. This happens for
instance in response to a GET_REPORT.