### PR TITLE
hiduniversal don't ignore same hiddata

### DIFF
--- a/hiduniversal.cpp
+++ b/hiduniversal.cpp
@@ -392,12 +392,12 @@ uint8_t HIDUniversal::Poll() {
                         if(read > constBuffLen)
                                 read = constBuffLen;
 
-                        bool identical = BuffersIdentical(read, buf, prevBuf);
+                        //bool identical = BuffersIdentical(read, buf, prevBuf);
 
-                        SaveBuffer(read, buf, prevBuf);
+                        //SaveBuffer(read, buf, prevBuf);
 
-                        if(identical)
-                                return 0;
+                        //if(identical)
+                        //        return 0;
 #if 0
                         Notify(PSTR("\r\nBuf: "), 0x80);
 


### PR DESCRIPTION
Only the first mouse wheel event can be received, if discard the same hiddata.
BTW: A Curious Thing, if annotated “ZeroMemory(constBuffLen, prevBuf);”, it can't poll any data ?