### PR TITLE
Flush the serial buffer

### DIFF
--- a/examples/USBH_MIDI/USB_MIDI_converter/USB_MIDI_converter.ino
+++ b/examples/USBH_MIDI/USB_MIDI_converter/USB_MIDI_converter.ino
@@ -68,6 +68,7 @@ void MIDI_poll()
     if ( (size = Midi.RecvData(outBuf)) > 0 ) {
       //MIDI Output
       _MIDI_SERIAL_PORT.write(outBuf, size);
+      _MIDI_SERIAL_PORT.flush()
     }
   } while (size > 0);
 }


### PR DESCRIPTION
With enough hammering, the buffer gets filled with more data than it can
handle and causes problems with the MIDI output. Ideally, there 
shouldn't be a buffer here in the first place, because we're dealing 
with constant time data anyway.

Flush the buffer after sending the USB host data to the serial port.