### PR TITLE
fix gcc warnings

### DIFF
--- a/XBOXONE.cpp
+++ b/XBOXONE.cpp
@@ -237,12 +237,14 @@ Fail:
 
 /* Extracts endpoint information from config descriptor */
 void XBOXONE::EndpointXtract(uint8_t conf,
-        uint8_t iface __attribute__((unused)),
-        uint8_t alt __attribute__((unused)),
-        uint8_t proto __attribute__((unused)),
-        const USB_ENDPOINT_DESCRIPTOR *pep)
+			     uint8_t iface,
+			     uint8_t alt,
+			     uint8_t proto,
+			     const USB_ENDPOINT_DESCRIPTOR *pep)
 {
-        
+  (void)iface;
+  (void)alt;
+  (void)proto;
     bConfNum = conf;
         uint8_t index;
 
@@ -262,9 +264,9 @@ void XBOXONE::EndpointXtract(uint8_t conf,
         bNumEP++;
 }
 
-void XBOXONE::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr
-    __attribute__((unused)))
+void XBOXONE::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr)
 {
+  (void)ep_ptr;
 #ifdef EXTRADEBUG
         Notify(PSTR("\r\nEndpoint descriptor:"), 0x80);
         Notify(PSTR("\r\nLength:\t\t"), 0x80);

--- a/confdescparser.h
+++ b/confdescparser.h
@@ -103,17 +103,21 @@ template <const uint8_t CLASS_ID, const uint8_t SUBCLASS_ID, const uint8_t PROTO
 bool ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::ParseDescriptor(uint8_t **pp, uint16_t *pcntdn) {
         USB_CONFIGURATION_DESCRIPTOR* ucd = reinterpret_cast<USB_CONFIGURATION_DESCRIPTOR*>(varBuffer);
         USB_INTERFACE_DESCRIPTOR* uid = reinterpret_cast<USB_INTERFACE_DESCRIPTOR*>(varBuffer);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough=3"
         switch(stateParseDescr) {
                 case 0:
                         theBuffer.valueSize = 2;
                         valParser.Initialize(&theBuffer);
                         stateParseDescr = 1;
+			/* FALLTHRU */
                 case 1:
                         if(!valParser.Parse(pp, pcntdn))
                                 return false;
                         dscrLen = *((uint8_t*)theBuffer.pValue);
                         dscrType = *((uint8_t*)theBuffer.pValue + 1);
                         stateParseDescr = 2;
+			/* FALLTHRU */
                 case 2:
                         // This is a sort of hack. Assuming that two bytes are all ready in the buffer
                         //      the pointer is positioned two bytes ahead in order for the rest of descriptor
@@ -122,6 +126,7 @@ bool ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::ParseDescriptor
                         //      in the buffer.
                         theBuffer.pValue = varBuffer + 2;
                         stateParseDescr = 3;
+			/* FALLTHRU */
                 case 3:
                         switch(dscrType) {
                                 case USB_DESCRIPTOR_INTERFACE:
@@ -135,6 +140,7 @@ bool ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::ParseDescriptor
                         theBuffer.valueSize = dscrLen - 2;
                         valParser.Initialize(&theBuffer);
                         stateParseDescr = 4;
+			/* FALLTHRU */
                 case 4:
                         switch(dscrType) {
                                 case USB_DESCRIPTOR_CONFIGURATION:
@@ -181,6 +187,7 @@ bool ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::ParseDescriptor
                         stateParseDescr = 0;
         }
         return true;
+#pragma GCC diagnostic pop
 }
 
 template <const uint8_t CLASS_ID, const uint8_t SUBCLASS_ID, const uint8_t PROTOCOL_ID, const uint8_t MASK>

--- a/hidboot.h
+++ b/hidboot.h
@@ -537,7 +537,8 @@ Fail:
 
 template <const uint8_t BOOT_PROTOCOL>
 void HIDBoot<BOOT_PROTOCOL>::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint8_t proto, const USB_ENDPOINT_DESCRIPTOR *pep) {
-
+	(void)alt;
+	(void)proto;
         // If the first configuration satisfies, the others are not considered.
         //if(bNumEP > 1 && conf != bConfNum)
         if(bNumEP == totalEndpoints(BOOT_PROTOCOL))

--- a/hidescriptorparser.cpp
+++ b/hidescriptorparser.cpp
@@ -1091,6 +1091,8 @@ void ReportDescParserBase::PrintItemTitle(uint8_t prefix) {
 uint8_t ReportDescParserBase::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
         //uint8_t ret = enErrorSuccess;
         //reinterpret_cast<>(varBuffer);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough=3"
         switch(itemParseState) {
                 case 0:
                         if(**pp == HID_LONG_ITEM_PREFIX)
@@ -1113,16 +1115,19 @@ uint8_t ReportDescParserBase::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
 
                         if(!pcntdn)
                                 return enErrorIncomplete;
+			/* FALLTHRU */
                 case 1:
                         //USBTRACE2("\r\niSz:",itemSize);
 
                         theBuffer.valueSize = itemSize;
                         valParser.Initialize(&theBuffer);
                         itemParseState = 2;
+			/* FALLTHRU */
                 case 2:
                         if(!valParser.Parse(pp, pcntdn))
                                 return enErrorIncomplete;
                         itemParseState = 3;
+			/* FALLTHRU */
                 case 3:
                 {
                         uint8_t data = *((uint8_t*)varBuffer);
@@ -1207,6 +1212,7 @@ uint8_t ReportDescParserBase::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
                         } // switch (**pp & (TYPE_MASK | TAG_MASK))
                 }
         } // switch (itemParseState)
+#pragma GCC diagnostic pop
         itemParseState = 0;
         return enErrorSuccess;
 }
@@ -1428,7 +1434,8 @@ void ReportDescParserBase::PrintMedicalInstrumentPageUsage(uint16_t usage) {
 
 uint8_t ReportDescParser2::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
         //uint8_t ret = enErrorSuccess;
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough=3"
         switch(itemParseState) {
                 case 0:
                         if(**pp == HID_LONG_ITEM_PREFIX)
@@ -1448,14 +1455,17 @@ uint8_t ReportDescParser2::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
 
                         if(!pcntdn)
                                 return enErrorIncomplete;
+			/* FALLTHRU */
                 case 1:
                         theBuffer.valueSize = itemSize;
                         valParser.Initialize(&theBuffer);
                         itemParseState = 2;
+			/* FALLTHRU */
                 case 2:
                         if(!valParser.Parse(pp, pcntdn))
                                 return enErrorIncomplete;
                         itemParseState = 3;
+			/* FALLTHRU */
                 case 3:
                 {
                         uint8_t data = *((uint8_t*)varBuffer);
@@ -1508,6 +1518,7 @@ uint8_t ReportDescParser2::ParseItem(uint8_t **pp, uint16_t *pcntdn) {
                         } // switch (**pp & (TYPE_MASK | TAG_MASK))
                 }
         } // switch (itemParseState)
+#pragma GCC diagnostic pop
         itemParseState = 0;
         return enErrorSuccess;
 }

--- a/parsetools.cpp
+++ b/parsetools.cpp
@@ -39,11 +39,14 @@ bool MultiByteValueParser::Parse(uint8_t **pp, uint16_t *pcntdn) {
 }
 
 bool PTPListParser::Parse(uint8_t **pp, uint16_t *pcntdn, PTP_ARRAY_EL_FUNC pf, const void *me) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough=3"
         switch(nStage) {
                 case 0:
                         pBuf->valueSize = lenSize;
                         theParser.Initialize(pBuf);
                         nStage = 1;
+			/* FALLTHRU */
 
                 case 1:
                         if(!theParser.Parse(pp, pcntdn))
@@ -53,11 +56,13 @@ bool PTPListParser::Parse(uint8_t **pp, uint16_t *pcntdn, PTP_ARRAY_EL_FUNC pf, 
                         arLen = (pBuf->valueSize >= 4) ? *((uint32_t*)pBuf->pValue) : (uint32_t)(*((uint16_t*)pBuf->pValue));
                         arLenCntdn = arLen;
                         nStage = 2;
+			/* FALLTHRU */
 
                 case 2:
                         pBuf->valueSize = valSize;
                         theParser.Initialize(pBuf);
                         nStage = 3;
+			/* FALLTHRU */
 
                 case 3:
                         for(; arLenCntdn; arLenCntdn--) {
@@ -70,5 +75,6 @@ bool PTPListParser::Parse(uint8_t **pp, uint16_t *pcntdn, PTP_ARRAY_EL_FUNC pf, 
 
                         nStage = 0;
         }
+#pragma GCC diagnostic pop
         return true;
 }

--- a/parsetools.h
+++ b/parsetools.h
@@ -75,10 +75,13 @@ public:
         };
 
         bool Skip(uint8_t **pp, uint16_t *pcntdn, uint16_t bytes_to_skip) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough=3"
                 switch(nStage) {
                         case 0:
                                 countDown = bytes_to_skip;
                                 nStage++;
+				/* FALLTHRU */
                         case 1:
                                 for(; countDown && (*pcntdn); countDown--, (*pp)++, (*pcntdn)--);
 
@@ -86,6 +89,7 @@ public:
                                         nStage = 0;
                 };
                 return (!countDown);
+#pragma GCC diagnostic pop
         };
 };
 

--- a/sink_parser.h
+++ b/sink_parser.h
@@ -42,6 +42,9 @@ public:
         };
 
         void Parse(const LEN_TYPE len, const uint8_t *pbuf, const OFFSET_TYPE &offset) {
+	  (void)len;
+	  (void)pbuf;
+	  (void)offset;
         };
 };
 

--- a/usbh_midi.cpp
+++ b/usbh_midi.cpp
@@ -572,6 +572,8 @@ uint8_t USBH_MIDI::SendSysEx(uint8_t *dataptr, uint16_t datasize, uint8_t nCable
                 //Byte 0
                 buf[wptr] = (nCable << 4) | 0x4;             //x4 SysEx starts or continues
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough=3"
                 switch ( n ) {
                     case 1 :
                         buf[wptr++] = (nCable << 4) | 0x5;   //x5 SysEx ends with following single byte.
@@ -589,6 +591,7 @@ uint8_t USBH_MIDI::SendSysEx(uint8_t *dataptr, uint16_t datasize, uint8_t nCable
                         break;
                     case 3 :
                         buf[wptr]   = (nCable << 4) | 0x7;   //x7 SysEx ends with following three bytes.
+			/* FALLTHRU */
                     default :
                         wptr++;
                         buf[wptr++] = *(dataptr++);
@@ -597,6 +600,7 @@ uint8_t USBH_MIDI::SendSysEx(uint8_t *dataptr, uint16_t datasize, uint8_t nCable
                         n = n - 3;
                         break;
                 }
+#pragma GCC diagnostic pop
 
                 if( wptr >= maxpkt || n == 0 ){ //Reach a maxPktSize or data end.
                         USBTRACE2(" wptr:\t", wptr);


### PR DESCRIPTION
these changes fix warnings with the latest Arduino IDE version.
- ignore warnings about case fall through.
- fix warning about unused parameter. I've opted for the "(void)var;" way, as I find it better than cluttering the parameter definition with the attribute unused.