### PR TITLE
Add Xbox Core Controller PID

### DIFF
--- a/XBOXONE.h
+++ b/XBOXONE.h
@@ -45,6 +45,7 @@
 #define XBOX_ONE_PID3                           0x02E3 // Microsoft X-Box One Elite pad
 #define XBOX_ONE_PID4                           0x02EA // Microsoft X-Box One S pad
 #define XBOX_ONE_PID13                          0x0B0A // Microsoft X-Box One Adaptive Controller
+#define XBOX_ONE_PID14                          0x0B12 // Microsoft X-Box Core Controller
 
 // Unofficial controllers
 #define XBOX_VID2                               0x0738 // Mad Catz
@@ -123,9 +124,10 @@ public:
          */
         virtual bool VIDPIDOK(uint16_t vid, uint16_t pid) {
                 return ((vid == XBOX_VID1 || vid == XBOX_VID2 || vid == XBOX_VID3 || vid == XBOX_VID4 || vid == XBOX_VID5 || vid == XBOX_VID6) &&
-                    (pid == XBOX_ONE_PID1 || pid == XBOX_ONE_PID2 || pid == XBOX_ONE_PID3 || pid == XBOX_ONE_PID4 ||
+                       (pid == XBOX_ONE_PID1 || pid == XBOX_ONE_PID2 || pid == XBOX_ONE_PID3 || pid == XBOX_ONE_PID4 ||
                         pid == XBOX_ONE_PID5 || pid == XBOX_ONE_PID6 || pid == XBOX_ONE_PID7 || pid == XBOX_ONE_PID8 ||
-                        pid == XBOX_ONE_PID9 || pid == XBOX_ONE_PID10 || pid == XBOX_ONE_PID11 || pid == XBOX_ONE_PID12 || pid == XBOX_ONE_PID13));
+                        pid == XBOX_ONE_PID9 || pid == XBOX_ONE_PID10 || pid == XBOX_ONE_PID11 || pid == XBOX_ONE_PID12 || 
+                        pid == XBOX_ONE_PID13 || pid == XBOX_ONE_PID14));
         };
         /**@}*/
 


### PR DESCRIPTION
Adds the PID for the new Xbox Series S / Series X "core" controllers to the `XBOXONE` wired USB class. Tested and working.

These controllers also include a new 'share' button, which is bit 0x01 of byte 22 in the report. Although since the `uint16_t` button variable is already full I'm not sure how best to add it to the class.