### PR TITLE
HIDUniversal, HIDComposite: Don't overflow hidInterfaces[] or epInfo[]

### DIFF
--- a/hidcomposite.cpp
+++ b/hidcomposite.cpp
@@ -306,6 +306,8 @@ void HIDComposite::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
 
         // Fill in interface structure in case of new interface
         if(!piface) {
+                if(bNumIface >= maxHidInterfaces)
+                        return; // don't overflow hidInterfaces[]
                 piface = hidInterfaces + bNumIface;
                 piface->bmInterface = iface;
                 piface->bmAltSet = alt;
@@ -319,7 +321,7 @@ void HIDComposite::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
         if(!SelectInterface(iface, proto))
                 index = 0;
 
-        if(index) {
+        if(index && bNumEP < totalEndpoints) {
                 // Fill in the endpoint info structure
                 epInfo[bNumEP].epAddr = (pep->bEndpointAddress & 0x0F);
                 epInfo[bNumEP].maxPktSize = (uint8_t)pep->wMaxPacketSize;

--- a/hidcomposite.cpp
+++ b/hidcomposite.cpp
@@ -306,8 +306,13 @@ void HIDComposite::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
 
         // Fill in interface structure in case of new interface
         if(!piface) {
-                if(bNumIface >= maxHidInterfaces)
-                        return; // don't overflow hidInterfaces[]
+                if(bNumIface >= maxHidInterfaces) {
+                        // don't overflow hidInterfaces[]
+                        Notify(PSTR("\r\n HIDComposite::EndpointXtract(): Not adding HID interface because we already have "), 0x80);
+                        Notify(bNumIface, 0x80);
+                        Notify(PSTR(" interfaces and can't hold more. "), 0x80);
+                        return;
+                }
                 piface = hidInterfaces + bNumIface;
                 piface->bmInterface = iface;
                 piface->bmAltSet = alt;
@@ -321,7 +326,14 @@ void HIDComposite::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
         if(!SelectInterface(iface, proto))
                 index = 0;
 
-        if(index && bNumEP < totalEndpoints) {
+        if(index) {
+                if(bNumEP >= totalEndpoints) {
+                        // don't overflow epInfo[] either
+                        Notify(PSTR("\r\n HIDComposite::EndpointXtract(): Not adding endpoint info because we already have "), 0x80);
+                        Notify(bNumEP, 0x80);
+                        Notify(PSTR(" endpoints and can't hold more. "), 0x80);
+                        return;
+                }
                 // Fill in the endpoint info structure
                 epInfo[bNumEP].epAddr = (pep->bEndpointAddress & 0x0F);
                 epInfo[bNumEP].maxPktSize = (uint8_t)pep->wMaxPacketSize;

--- a/hiduniversal.cpp
+++ b/hiduniversal.cpp
@@ -308,8 +308,13 @@ void HIDUniversal::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
 
         // Fill in interface structure in case of new interface
         if(!piface) {
-            if(bNumIface >= maxHidInterfaces)
-                    return; // don't overflow hidInterfaces[]
+                if(bNumIface >= maxHidInterfaces) {
+                        // don't overflow hidInterfaces[]
+                        Notify(PSTR("\r\n HIDUniversal::EndpointXtract(): Not adding HID interface because we already have "), 0x80);
+                        Notify(bNumIface, 0x80);
+                        Notify(PSTR(" interfaces and can't hold more. "), 0x80);
+                        return;
+                }
                 piface = hidInterfaces + bNumIface;
                 piface->bmInterface = iface;
                 piface->bmAltSet = alt;
@@ -320,7 +325,14 @@ void HIDUniversal::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
         if((pep->bmAttributes & bmUSB_TRANSFER_TYPE) == USB_TRANSFER_TYPE_INTERRUPT)
                 index = (pep->bEndpointAddress & 0x80) == 0x80 ? epInterruptInIndex : epInterruptOutIndex;
 
-        if(index && bNumEP < totalEndpoints) {
+        if(index) {
+                if(bNumEP >= totalEndpoints) {
+                        // don't overflow epInfo[] either
+                        Notify(PSTR("\r\n HIDUniversal::EndpointXtract(): Not adding endpoint info because we already have "), 0x80);
+                        Notify(bNumEP, 0x80);
+                        Notify(PSTR(" endpoints and can't hold more. "), 0x80);
+                        return;
+                }
                 // Fill in the endpoint info structure
                 epInfo[bNumEP].epAddr = (pep->bEndpointAddress & 0x0F);
                 epInfo[bNumEP].maxPktSize = (uint8_t)pep->wMaxPacketSize;

--- a/hiduniversal.cpp
+++ b/hiduniversal.cpp
@@ -308,6 +308,8 @@ void HIDUniversal::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
 
         // Fill in interface structure in case of new interface
         if(!piface) {
+            if(bNumIface >= maxHidInterfaces)
+                    return; // don't overflow hidInterfaces[]
                 piface = hidInterfaces + bNumIface;
                 piface->bmInterface = iface;
                 piface->bmAltSet = alt;
@@ -318,7 +320,7 @@ void HIDUniversal::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
         if((pep->bmAttributes & bmUSB_TRANSFER_TYPE) == USB_TRANSFER_TYPE_INTERRUPT)
                 index = (pep->bEndpointAddress & 0x80) == 0x80 ? epInterruptInIndex : epInterruptOutIndex;
 
-        if(index) {
+        if(index && bNumEP < totalEndpoints) {
                 // Fill in the endpoint info structure
                 epInfo[bNumEP].epAddr = (pep->bEndpointAddress & 0x0F);
                 epInfo[bNumEP].maxPktSize = (uint8_t)pep->wMaxPacketSize;

--- a/usbhid.h
+++ b/usbhid.h
@@ -149,7 +149,7 @@ protected:
         static const uint8_t epInterruptInIndex = 1; // InterruptIN  endpoint index
         static const uint8_t epInterruptOutIndex = 2; // InterruptOUT endpoint index
 
-        static const uint8_t maxHidInterfaces = 3;
+        static const uint8_t maxHidInterfaces = 5;
         static const uint8_t maxEpPerInterface = 2;
         static const uint8_t totalEndpoints = (maxHidInterfaces * maxEpPerInterface + 1); // We need to make room for the control endpoint
 


### PR DESCRIPTION
If a connected device has more than 3 (maxHidInterfaces) HID interfaces,
which is not unusual with modern keyboards, EndpointXtract() wrote
beyond the hidInterfaces[] array and corrupted bHasReportId, PID + VID.

The same could happen with the epInfo[] array.
Now this is fixed by checking bNumIface/bNumEP before adding new
elements to those arrays.