### PR TITLE
Fix for handling MIDI channels in the bidirectional converter example

### DIFF
--- a/examples/USBH_MIDI/bidirectional_converter/bidirectional_converter.ino
+++ b/examples/USBH_MIDI/bidirectional_converter/bidirectional_converter.ino
@@ -44,7 +44,7 @@ MIDI_CREATE_DEFAULT_INSTANCE();
 //////////////////////////
 
 USB Usb;
-USBHub  Hub1(&Usb);
+//USBHub  Hub1(&Usb);
 USBH_MIDI Midi(&Usb);
 
 void MIDI_poll();

--- a/examples/USBH_MIDI/bidirectional_converter/bidirectional_converter.ino
+++ b/examples/USBH_MIDI/bidirectional_converter/bidirectional_converter.ino
@@ -88,8 +88,10 @@ void loop()
           //SysEx is handled by event.
           break;
         default :
+          // If this is a channel messages, set the channel number.
           if( msg[0] < 0xf0 ){
-            msg[0] |= MIDI.getChannel() - 1;
+            // The getchannel() returns 1-16, but the MIDI status byte starts at 0.
+            msg[0] |= MIDI.getChannel() - 1; 
           }
           msg[1] = MIDI.getData1();
           msg[2] = MIDI.getData2();

--- a/examples/USBH_MIDI/bidirectional_converter/bidirectional_converter.ino
+++ b/examples/USBH_MIDI/bidirectional_converter/bidirectional_converter.ino
@@ -1,7 +1,7 @@
 /*
  *******************************************************************************
  * Legacy Serial MIDI and USB Host bidirectional converter
- * Copyright (C) 2013-2020 Yuuichi Akagawa
+ * Copyright (C) 2013-2021 Yuuichi Akagawa
  *
  * for use with Arduino MIDI library
  * https://github.com/FortySevenEffects/arduino_midi_library/
@@ -44,6 +44,7 @@ MIDI_CREATE_DEFAULT_INSTANCE();
 //////////////////////////
 
 USB Usb;
+USBHub  Hub1(&Usb);
 USBH_MIDI Midi(&Usb);
 
 void MIDI_poll();
@@ -87,6 +88,9 @@ void loop()
           //SysEx is handled by event.
           break;
         default :
+          if( msg[0] < 0xf0 ){
+            msg[0] |= MIDI.getChannel() - 1;
+          }
           msg[1] = MIDI.getData1();
           msg[2] = MIDI.getData2();
           Midi.SendData(msg, 0);


### PR DESCRIPTION
Fix for handling MIDI channels in the bidirectional converter example (#586)