### PR TITLE
Added support for Adafruit NRF52840 Feather Express 

### DIFF
--- a/SPP.h
+++ b/SPP.h
@@ -114,7 +114,7 @@ public:
          */
         size_t write(const uint8_t* data, size_t size);
         /** Pull in write(const char *str) from Print */
-#if !defined(RBL_NRF51822)
+#if !defined(RBL_NRF51822) && !defined(NRF52_SERIES)
         using Print::write;
 #endif
 #else

--- a/avrpins.h
+++ b/avrpins.h
@@ -1294,6 +1294,68 @@ MAKE_PIN(P19, GPIOC, GPIO_PIN_0); // A5
 
 #undef MAKE_PIN
 
+
+#elif defined(ARDUINO_NRF52840_FEATHER)
+
+#define MAKE_PIN(className, pin) \
+class className { \
+public: \
+    static void Set() { \
+        nrf_gpio_pin_set(pin); \
+    } \
+    static void Clear() { \
+        nrf_gpio_pin_clear(pin); \
+    } \
+    static void SetDirRead() { \
+        nrf_gpio_cfg_input(pin, NRF_GPIO_PIN_NOPULL); \
+    } \
+    static void SetDirWrite() { \
+        nrf_gpio_cfg_output(pin); \
+    } \
+    static uint8_t IsSet() { \
+        return (uint8_t)nrf_gpio_pin_read(pin); \
+    } \
+};
+
+// Based on variants/feather_nrf52840_express/variant.cpp
+// g_ADigitalPinMap ould be used directly, but it would be slower
+MAKE_PIN(P0, (25));
+MAKE_PIN(P1, (24));
+MAKE_PIN(P2, (10));
+MAKE_PIN(P3, (47));
+MAKE_PIN(P4, (42));
+MAKE_PIN(P5, (40));
+MAKE_PIN(P6, (7));
+MAKE_PIN(P7, (34));
+MAKE_PIN(P8, (16));
+MAKE_PIN(P9, (26));
+MAKE_PIN(P10, (27));
+MAKE_PIN(P11, (6));
+MAKE_PIN(P12, (8));
+MAKE_PIN(P13, (41));
+MAKE_PIN(P14, (4));
+MAKE_PIN(P15, (5));
+MAKE_PIN(P17, (30));
+MAKE_PIN(P18, (28));
+MAKE_PIN(P16, (2));
+MAKE_PIN(P19, (3));
+MAKE_PIN(P20, (29));
+MAKE_PIN(P21, (31));
+MAKE_PIN(P22, (12));
+MAKE_PIN(P23, (11));
+MAKE_PIN(P24, (15));
+MAKE_PIN(P25, (13));
+MAKE_PIN(P26, (14));
+MAKE_PIN(P27, (19));
+MAKE_PIN(P28, (20));
+MAKE_PIN(P29, (17));
+MAKE_PIN(P30, (22));
+MAKE_PIN(P31, (23));
+MAKE_PIN(P32, (21));
+MAKE_PIN(P33, (9));
+
+#undef MAKE_PIN
+
 #else
 #error "Please define board in avrpins.h"
 

--- a/avrpins.h
+++ b/avrpins.h
@@ -1318,7 +1318,7 @@ public: \
 };
 
 // Based on variants/feather_nrf52840_express/variant.cpp
-// g_ADigitalPinMap ould be used directly, but it would be slower
+// g_ADigitalPinMap could be used directly, but it would be slower
 MAKE_PIN(P0, (25));
 MAKE_PIN(P1, (24));
 MAKE_PIN(P2, (10));

--- a/settings.h
+++ b/settings.h
@@ -157,6 +157,11 @@ e-mail   :  support@circuitsathome.com
 #define SPI SPI_Master
 #define MFK_CASTUINT8T (uint8_t) // RBLs return type for sizeof needs casting to uint8_t
 #endif
+#ifdef NRF52_SERIES
+#include <SPI.h> 
+#include <nrf_gpio.h>
+#define MFK_CASTUINT8T (uint8_t) // NRF return type for sizeof needs casting to uint8_t
+#endif
 #if defined(__PIC32MX__) || defined(__PIC32MZ__)
 #include <../../../../hardware/pic32/libraries/SPI/SPI.h> // Hack to use the SPI library
 #endif

--- a/usbhost.h
+++ b/usbhost.h
@@ -70,7 +70,7 @@ public:
                 #else
                     USB_SPI.setClockDivider(SPI_CLOCK_DIV2); // This will set the SPI frequency to 8MHz - it could be higher, but it is not supported in the old API
                 #endif
-#elif !defined(RBL_NRF51822)
+#elif !defined(RBL_NRF51822) && !defined(NRF52_SERIES)
                 USB_SPI.setClockDivider(4); // Set speed to 84MHz/4=21MHz - the MAX3421E can handle up to 26MHz
 #endif
         }
@@ -120,6 +120,8 @@ typedef SPi< P16, P18, P17, P10 > spi;
 typedef SPi< P14, P13, P12, P15 > spi;
 #elif defined(ESP32)
 typedef SPi< P18, P23, P19, P5 > spi;
+#elif defined(ARDUINO_NRF52840_FEATHER)
+typedef SPi< P26, P25, P24, P5 > spi;
 #else
 #error "No SPI entry in usbhost.h"
 #endif


### PR DESCRIPTION
Added definitions for Adafruit NRF52840 Feather Express based on the existing RBL_NRF51822 variant.
I left portions that apply to the whole NRF52 series under generic #ifdef sections to make adding other NRF52 series boards easier in the future. They should just require their own MAKE_PIN section and `typedef SPi` with board specific SPI pin configuration.

I was hoping to find a clean way to support generic NRF boards, but doing some sort of #define based loop seems like it would just make things hard to follow versus the straight forward but redundant MAKE_PIN section here.

The PS5 controller and USB_desc examples have been tested and seem to work fine with a knock off Duinofun USBmini 2.0 shield (after accounting for the mislabeled pins on this hardware, and cutting the USB VDD trace to wire it to 5V).