### PR TITLE
Recover from OUT-NAK

### DIFF
--- a/Usb.cpp
+++ b/Usb.cpp
@@ -388,6 +388,11 @@ uint8_t USB::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8
                 data_p += bytes_tosend;
         }//while( bytes_left...
 breakout:
+        /* If rcode(=rHRSL) is non-zero, untransmitted data remains in the SNDFIFO. */
+        if(rcode != 0) {
+            //Switch the FIFO containing the OUT data back under microcontroller control and reset pointer.
+            regWr(rSNDBC, 0);
+        }
 
         pep->bmSndToggle = (regRd(rHRSL) & bmSNDTOGRD) ? 1 : 0; //bmSNDTOG1 : bmSNDTOG0;  //update toggle
         return ( rcode); //should be 0 in all cases


### PR DESCRIPTION
SNDFIFO is not cleared when USB::OutTransfer() does not complete successfully.
See also #607 

It seems that we can recover with SNDBC=0 according to the following part of [APPLICATION NOTE 4000](https://www.maximintegrated.com/en/design/technical-documents/app-notes/4/4000.html).
> Programming Single-Buffered Transfers
> -- snip --
>    2. If NAK, go to the next step.
>  6. Reload the first FIFO byte, and relaunch the transfer:
>    1. Write SNDBC = 0, a dummy value to switch the FIFO containing the OUT data back under microcontroller control.
