### PR TITLE
Make ButtonEnum values unique

### DIFF
--- a/PS3BT.cpp
+++ b/PS3BT.cpp
@@ -47,12 +47,12 @@ BluetoothService(p) // Pointer to USB class instance - mandatory
 }
 
 bool PS3BT::getButtonPress(ButtonEnum b) {
-        const int8_t index = getPS3ButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS3(b); if (index < 0) return 0;
         return (ButtonState & pgm_read_dword(&PS3_BUTTONS[index]));
 }
 
 bool PS3BT::getButtonClick(ButtonEnum b) {
-        const int8_t index = getPS3ButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS3(b); if (index < 0) return 0;
         uint32_t button = pgm_read_dword(&PS3_BUTTONS[index]);
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // Clear "click" event
@@ -60,7 +60,7 @@ bool PS3BT::getButtonClick(ButtonEnum b) {
 }
 
 uint8_t PS3BT::getAnalogButton(ButtonEnum a) {
-        const int8_t index = getPS3ButtonIndex(a); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS3(a); if (index < 0) return 0;
         return (uint8_t)(l2capinbuf[pgm_read_byte(&PS3_ANALOG_BUTTONS[index])]);
 }
 

--- a/PS3BT.cpp
+++ b/PS3BT.cpp
@@ -47,18 +47,21 @@ BluetoothService(p) // Pointer to USB class instance - mandatory
 }
 
 bool PS3BT::getButtonPress(ButtonEnum b) {
-        return (ButtonState & pgm_read_dword(&PS3_BUTTONS[(uint8_t)b]));
+        const int8_t index = getPS3ButtonIndex(b); if (index < 0) return 0;
+        return (ButtonState & pgm_read_dword(&PS3_BUTTONS[index]));
 }
 
 bool PS3BT::getButtonClick(ButtonEnum b) {
-        uint32_t button = pgm_read_dword(&PS3_BUTTONS[(uint8_t)b]);
+        const int8_t index = getPS3ButtonIndex(b); if (index < 0) return 0;
+        uint32_t button = pgm_read_dword(&PS3_BUTTONS[index]);
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // Clear "click" event
         return click;
 }
 
 uint8_t PS3BT::getAnalogButton(ButtonEnum a) {
-        return (uint8_t)(l2capinbuf[pgm_read_byte(&PS3_ANALOG_BUTTONS[(uint8_t)a])]);
+        const int8_t index = getPS3ButtonIndex(a); if (index < 0) return 0;
+        return (uint8_t)(l2capinbuf[pgm_read_byte(&PS3_ANALOG_BUTTONS[index])]);
 }
 
 uint8_t PS3BT::getAnalogHat(AnalogHatEnum a) {

--- a/PS3Enums.h
+++ b/PS3Enums.h
@@ -138,8 +138,10 @@ enum StatusEnum {
         Bluetooth = (40 << 8) | 0x16, // Operating by Bluetooth and rumble is turned off
 };
 
-inline constexpr int8_t getPS3ButtonIndex(ButtonEnum b) {
-        return (uint8_t) legacyButtonValues(b) >= (sizeof(PS3_BUTTONS) / sizeof(PS3_BUTTONS[0])) ? -1 : legacyButtonValues(b);
+inline int8_t getPS3ButtonIndex(ButtonEnum b) {
+    const int8_t index = legacyButtonValues(b);
+    if ((uint8_t) index >= (sizeof(PS3_BUTTONS) / sizeof(PS3_BUTTONS[0]))) return -1;
+    return index;
 }
 
 #endif

--- a/PS3Enums.h
+++ b/PS3Enums.h
@@ -139,8 +139,8 @@ enum StatusEnum {
 };
 
 inline int8_t getPS3ButtonIndex(ButtonEnum b) {
-    const uint8_t index = legacyButtonValues(b);
-    if (index >= sizeof(PS3_BUTTONS) / sizeof(PS3_BUTTONS[0])) return -1;
+    const int8_t index = legacyButtonValues(b);
+    if ((uint8_t) index >= (sizeof(PS3_BUTTONS) / sizeof(PS3_BUTTONS[0]))) return -1;
     return index;
 }
 

--- a/PS3Enums.h
+++ b/PS3Enums.h
@@ -138,4 +138,10 @@ enum StatusEnum {
         Bluetooth = (40 << 8) | 0x16, // Operating by Bluetooth and rumble is turned off
 };
 
+inline int8_t getPS3ButtonIndex(ButtonEnum b) {
+    const uint8_t index = legacyButtonValues(b);
+    if (index >= sizeof(PS3_BUTTONS) / sizeof(PS3_BUTTONS[0])) return -1;
+    return index;
+}
+
 #endif

--- a/PS3Enums.h
+++ b/PS3Enums.h
@@ -138,10 +138,8 @@ enum StatusEnum {
         Bluetooth = (40 << 8) | 0x16, // Operating by Bluetooth and rumble is turned off
 };
 
-inline int8_t getPS3ButtonIndex(ButtonEnum b) {
-    const int8_t index = legacyButtonValues(b);
-    if ((uint8_t) index >= (sizeof(PS3_BUTTONS) / sizeof(PS3_BUTTONS[0]))) return -1;
-    return index;
+inline constexpr int8_t getPS3ButtonIndex(ButtonEnum b) {
+        return (uint8_t) legacyButtonValues(b) >= (sizeof(PS3_BUTTONS) / sizeof(PS3_BUTTONS[0])) ? -1 : legacyButtonValues(b);
 }
 
 #endif

--- a/PS3Enums.h
+++ b/PS3Enums.h
@@ -138,8 +138,8 @@ enum StatusEnum {
         Bluetooth = (40 << 8) | 0x16, // Operating by Bluetooth and rumble is turned off
 };
 
-inline int8_t getPS3ButtonIndex(ButtonEnum b) {
-    const int8_t index = legacyButtonValues(b);
+inline int8_t getButtonIndexPS3(ButtonEnum b) {
+    const int8_t index = ButtonIndex(b);
     if ((uint8_t) index >= (sizeof(PS3_BUTTONS) / sizeof(PS3_BUTTONS[0]))) return -1;
     return index;
 }

--- a/PS3USB.cpp
+++ b/PS3USB.cpp
@@ -314,12 +314,12 @@ void PS3USB::printReport() { // Uncomment "#define PRINTREPORT" to print the rep
 }
 
 bool PS3USB::getButtonPress(ButtonEnum b) {
-        const int8_t index = getPS3ButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS3(b); if (index < 0) return 0;
         return (ButtonState & pgm_read_dword(&PS3_BUTTONS[index]));
 }
 
 bool PS3USB::getButtonClick(ButtonEnum b) {
-        const int8_t index = getPS3ButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS3(b); if (index < 0) return 0;
         uint32_t button = pgm_read_dword(&PS3_BUTTONS[index]);
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // Clear "click" event
@@ -327,7 +327,7 @@ bool PS3USB::getButtonClick(ButtonEnum b) {
 }
 
 uint8_t PS3USB::getAnalogButton(ButtonEnum a) {
-        const int8_t index = getPS3ButtonIndex(a); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS3(a); if (index < 0) return 0;
         return (uint8_t)(readBuf[(pgm_read_byte(&PS3_ANALOG_BUTTONS[index])) - 9]);
 }
 

--- a/PS3USB.cpp
+++ b/PS3USB.cpp
@@ -314,18 +314,21 @@ void PS3USB::printReport() { // Uncomment "#define PRINTREPORT" to print the rep
 }
 
 bool PS3USB::getButtonPress(ButtonEnum b) {
-        return (ButtonState & pgm_read_dword(&PS3_BUTTONS[(uint8_t)b]));
+        const int8_t index = getPS3ButtonIndex(b); if (index < 0) return 0;
+        return (ButtonState & pgm_read_dword(&PS3_BUTTONS[index]));
 }
 
 bool PS3USB::getButtonClick(ButtonEnum b) {
-        uint32_t button = pgm_read_dword(&PS3_BUTTONS[(uint8_t)b]);
+        const int8_t index = getPS3ButtonIndex(b); if (index < 0) return 0;
+        uint32_t button = pgm_read_dword(&PS3_BUTTONS[index]);
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // Clear "click" event
         return click;
 }
 
 uint8_t PS3USB::getAnalogButton(ButtonEnum a) {
-        return (uint8_t)(readBuf[(pgm_read_byte(&PS3_ANALOG_BUTTONS[(uint8_t)a])) - 9]);
+        const int8_t index = getPS3ButtonIndex(a); if (index < 0) return 0;
+        return (uint8_t)(readBuf[(pgm_read_byte(&PS3_ANALOG_BUTTONS[index])) - 9]);
 }
 
 uint8_t PS3USB::getAnalogHat(AnalogHatEnum a) {

--- a/PS4Parser.cpp
+++ b/PS4Parser.cpp
@@ -70,9 +70,10 @@ bool PS4Parser::getButtonClick(ButtonEnum b) {
 }
 
 uint8_t PS4Parser::getAnalogButton(ButtonEnum b) {
-        if (b == L2) // These are the only analog buttons on the controller
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        if (index == legacyButtonValues(L2)) // These are the only analog buttons on the controller
                 return ps4Data.trigger[0];
-        else if (b == R2)
+        else if (index == legacyButtonValues(R2))
                 return ps4Data.trigger[1];
         return 0;
 }

--- a/PS4Parser.cpp
+++ b/PS4Parser.cpp
@@ -32,8 +32,8 @@ enum DPADEnum {
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS4 Controller
 
-int8_t PS4Parser::getButtonIndex(ButtonEnum b) {
-    const int8_t index = legacyButtonValues(b);
+int8_t PS4Parser::getButtonIndexPS4(ButtonEnum b) {
+    const int8_t index = ButtonIndex(b);
     if ((uint8_t) index >= (sizeof(PS4_BUTTONS) / sizeof(PS4_BUTTONS[0]))) return -1;
     return index;
 }
@@ -54,7 +54,7 @@ bool PS4Parser::checkDpad(ButtonEnum b) {
 }
 
 bool PS4Parser::getButtonPress(ButtonEnum b) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS4(b); if (index < 0) return 0;
         if (index <= LEFT) // Dpad
                 return checkDpad(b);
         else
@@ -62,7 +62,7 @@ bool PS4Parser::getButtonPress(ButtonEnum b) {
 }
 
 bool PS4Parser::getButtonClick(ButtonEnum b) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS4(b); if (index < 0) return 0;
         uint32_t mask = 1UL << pgm_read_byte(&PS4_BUTTONS[index]);
         bool click = buttonClickState.val & mask;
         buttonClickState.val &= ~mask; // Clear "click" event
@@ -70,10 +70,10 @@ bool PS4Parser::getButtonClick(ButtonEnum b) {
 }
 
 uint8_t PS4Parser::getAnalogButton(ButtonEnum b) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
-        if (index == legacyButtonValues(L2)) // These are the only analog buttons on the controller
+        const int8_t index = getButtonIndexPS4(b); if (index < 0) return 0;
+        if (index == ButtonIndex(L2)) // These are the only analog buttons on the controller
                 return ps4Data.trigger[0];
-        else if (index == legacyButtonValues(R2))
+        else if (index == ButtonIndex(R2))
                 return ps4Data.trigger[1];
         return 0;
 }

--- a/PS4Parser.cpp
+++ b/PS4Parser.cpp
@@ -33,8 +33,8 @@ enum DPADEnum {
 //#define PRINTREPORT // Uncomment to print the report send by the PS4 Controller
 
 int8_t PS4Parser::getButtonIndex(ButtonEnum b) {
-    const uint8_t index = legacyButtonValues(b);
-    if (index >= sizeof(PS4_BUTTONS) / sizeof(PS4_BUTTONS[0])) return -1;
+    const int8_t index = legacyButtonValues(b);
+    if ((uint8_t) index >= (sizeof(PS4_BUTTONS) / sizeof(PS4_BUTTONS[0]))) return -1;
     return index;
 }
 

--- a/PS4Parser.cpp
+++ b/PS4Parser.cpp
@@ -32,10 +32,8 @@ enum DPADEnum {
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS4 Controller
 
-int8_t PS4Parser::getButtonIndex(ButtonEnum b) {
-    const int8_t index = legacyButtonValues(b);
-    if ((uint8_t) index >= (sizeof(PS4_BUTTONS) / sizeof(PS4_BUTTONS[0]))) return -1;
-    return index;
+inline constexpr int8_t PS4Parser::getButtonIndex(ButtonEnum b) {
+        return (uint8_t) legacyButtonValues(b) >= (sizeof(PS4_BUTTONS) / sizeof(PS4_BUTTONS[0])) ? -1 : legacyButtonValues(b);
 }
 
 bool PS4Parser::checkDpad(ButtonEnum b) {

--- a/PS4Parser.cpp
+++ b/PS4Parser.cpp
@@ -32,8 +32,10 @@ enum DPADEnum {
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS4 Controller
 
-inline constexpr int8_t PS4Parser::getButtonIndex(ButtonEnum b) {
-        return (uint8_t) legacyButtonValues(b) >= (sizeof(PS4_BUTTONS) / sizeof(PS4_BUTTONS[0])) ? -1 : legacyButtonValues(b);
+int8_t PS4Parser::getButtonIndex(ButtonEnum b) {
+    const int8_t index = legacyButtonValues(b);
+    if ((uint8_t) index >= (sizeof(PS4_BUTTONS) / sizeof(PS4_BUTTONS[0]))) return -1;
+    return index;
 }
 
 bool PS4Parser::checkDpad(ButtonEnum b) {

--- a/PS4Parser.cpp
+++ b/PS4Parser.cpp
@@ -32,6 +32,12 @@ enum DPADEnum {
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS4 Controller
 
+int8_t PS4Parser::getButtonIndex(ButtonEnum b) {
+    const uint8_t index = legacyButtonValues(b);
+    if (index >= sizeof(PS4_BUTTONS) / sizeof(PS4_BUTTONS[0])) return -1;
+    return index;
+}
+
 bool PS4Parser::checkDpad(ButtonEnum b) {
         switch (b) {
                 case UP:
@@ -48,14 +54,16 @@ bool PS4Parser::checkDpad(ButtonEnum b) {
 }
 
 bool PS4Parser::getButtonPress(ButtonEnum b) {
-        if (b <= LEFT) // Dpad
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        if (index <= LEFT) // Dpad
                 return checkDpad(b);
         else
-                return ps4Data.btn.val & (1UL << pgm_read_byte(&PS4_BUTTONS[(uint8_t)b]));
+                return ps4Data.btn.val & (1UL << pgm_read_byte(&PS4_BUTTONS[index]));
 }
 
 bool PS4Parser::getButtonClick(ButtonEnum b) {
-        uint32_t mask = 1UL << pgm_read_byte(&PS4_BUTTONS[(uint8_t)b]);
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        uint32_t mask = 1UL << pgm_read_byte(&PS4_BUTTONS[index]);
         bool click = buttonClickState.val & mask;
         buttonClickState.val &= ~mask; // Clear "click" event
         return click;

--- a/PS4Parser.h
+++ b/PS4Parser.h
@@ -362,6 +362,7 @@ protected:
         virtual void sendOutputReport(PS4Output *output) = 0;
 
 private:
+        static int8_t getButtonIndex(ButtonEnum b);
         bool checkDpad(ButtonEnum b); // Used to check PS4 DPAD buttons
 
         PS4Data ps4Data;

--- a/PS4Parser.h
+++ b/PS4Parser.h
@@ -362,7 +362,7 @@ protected:
         virtual void sendOutputReport(PS4Output *output) = 0;
 
 private:
-        static inline constexpr int8_t getButtonIndex(ButtonEnum b);
+        static int8_t getButtonIndex(ButtonEnum b);
         bool checkDpad(ButtonEnum b); // Used to check PS4 DPAD buttons
 
         PS4Data ps4Data;

--- a/PS4Parser.h
+++ b/PS4Parser.h
@@ -362,7 +362,7 @@ protected:
         virtual void sendOutputReport(PS4Output *output) = 0;
 
 private:
-        static int8_t getButtonIndex(ButtonEnum b);
+        static inline constexpr int8_t getButtonIndex(ButtonEnum b);
         bool checkDpad(ButtonEnum b); // Used to check PS4 DPAD buttons
 
         PS4Data ps4Data;

--- a/PS4Parser.h
+++ b/PS4Parser.h
@@ -362,7 +362,7 @@ protected:
         virtual void sendOutputReport(PS4Output *output) = 0;
 
 private:
-        static int8_t getButtonIndex(ButtonEnum b);
+        static int8_t getButtonIndexPS4(ButtonEnum b);
         bool checkDpad(ButtonEnum b); // Used to check PS4 DPAD buttons
 
         PS4Data ps4Data;

--- a/PS5Parser.cpp
+++ b/PS5Parser.cpp
@@ -74,9 +74,10 @@ bool PS5Parser::getButtonClick(ButtonEnum b) {
 }
 
 uint8_t PS5Parser::getAnalogButton(ButtonEnum b) {
-        if (b == L2) // These are the only analog buttons on the controller
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        if (index == legacyButtonValues(L2)) // These are the only analog buttons on the controller
                 return ps5Data.trigger[0];
-        else if (b == R2)
+        else if (index == legacyButtonValues(R2))
                 return ps5Data.trigger[1];
         return 0;
 }

--- a/PS5Parser.cpp
+++ b/PS5Parser.cpp
@@ -36,6 +36,12 @@ enum DPADEnum {
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS5 Controller
 
+int8_t PS5Parser::getButtonIndex(ButtonEnum b) {
+    const uint8_t index = legacyButtonValues(b);
+    if (index >= sizeof(PS5_BUTTONS) / sizeof(PS5_BUTTONS[0])) return -1;
+    return index;
+}
+
 bool PS5Parser::checkDpad(ButtonEnum b) {
         switch (b) {
                 case UP:
@@ -52,14 +58,16 @@ bool PS5Parser::checkDpad(ButtonEnum b) {
 }
 
 bool PS5Parser::getButtonPress(ButtonEnum b) {
-        if (b <= LEFT) // Dpad
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        if (index <= LEFT) // Dpad
                 return checkDpad(b);
         else
-                return ps5Data.btn.val & (1UL << pgm_read_byte(&PS5_BUTTONS[(uint8_t)b]));
+                return ps5Data.btn.val & (1UL << pgm_read_byte(&PS5_BUTTONS[index]));
 }
 
 bool PS5Parser::getButtonClick(ButtonEnum b) {
-        uint32_t mask = 1UL << pgm_read_byte(&PS5_BUTTONS[(uint8_t)b]);
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        uint32_t mask = 1UL << pgm_read_byte(&PS5_BUTTONS[index]);
         bool click = buttonClickState.val & mask;
         buttonClickState.val &= ~mask; // Clear "click" event
         return click;

--- a/PS5Parser.cpp
+++ b/PS5Parser.cpp
@@ -36,8 +36,8 @@ enum DPADEnum {
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS5 Controller
 
-int8_t PS5Parser::getButtonIndex(ButtonEnum b) {
-    const int8_t index = legacyButtonValues(b);
+int8_t PS5Parser::getButtonIndexPS5(ButtonEnum b) {
+    const int8_t index = ButtonIndex(b);
     if ((uint8_t) index >= (sizeof(PS5_BUTTONS) / sizeof(PS5_BUTTONS[0]))) return -1;
     return index;
 }
@@ -58,7 +58,7 @@ bool PS5Parser::checkDpad(ButtonEnum b) {
 }
 
 bool PS5Parser::getButtonPress(ButtonEnum b) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS5(b); if (index < 0) return 0;
         if (index <= LEFT) // Dpad
                 return checkDpad(b);
         else
@@ -66,7 +66,7 @@ bool PS5Parser::getButtonPress(ButtonEnum b) {
 }
 
 bool PS5Parser::getButtonClick(ButtonEnum b) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexPS5(b); if (index < 0) return 0;
         uint32_t mask = 1UL << pgm_read_byte(&PS5_BUTTONS[index]);
         bool click = buttonClickState.val & mask;
         buttonClickState.val &= ~mask; // Clear "click" event
@@ -74,10 +74,10 @@ bool PS5Parser::getButtonClick(ButtonEnum b) {
 }
 
 uint8_t PS5Parser::getAnalogButton(ButtonEnum b) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
-        if (index == legacyButtonValues(L2)) // These are the only analog buttons on the controller
+        const int8_t index = getButtonIndexPS5(b); if (index < 0) return 0;
+        if (index == ButtonIndex(L2)) // These are the only analog buttons on the controller
                 return ps5Data.trigger[0];
-        else if (index == legacyButtonValues(R2))
+        else if (index == ButtonIndex(R2))
                 return ps5Data.trigger[1];
         return 0;
 }

--- a/PS5Parser.cpp
+++ b/PS5Parser.cpp
@@ -36,10 +36,8 @@ enum DPADEnum {
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS5 Controller
 
-int8_t PS5Parser::getButtonIndex(ButtonEnum b) {
-    const int8_t index = legacyButtonValues(b);
-    if ((uint8_t) index >= (sizeof(PS5_BUTTONS) / sizeof(PS5_BUTTONS[0]))) return -1;
-    return index;
+inline constexpr int8_t PS5Parser::getButtonIndex(ButtonEnum b) {
+        return (uint8_t) legacyButtonValues(b) >= (sizeof(PS5_BUTTONS) / sizeof(PS5_BUTTONS[0])) ? -1 : legacyButtonValues(b);
 }
 
 bool PS5Parser::checkDpad(ButtonEnum b) {

--- a/PS5Parser.cpp
+++ b/PS5Parser.cpp
@@ -37,8 +37,8 @@ enum DPADEnum {
 //#define PRINTREPORT // Uncomment to print the report send by the PS5 Controller
 
 int8_t PS5Parser::getButtonIndex(ButtonEnum b) {
-    const uint8_t index = legacyButtonValues(b);
-    if (index >= sizeof(PS5_BUTTONS) / sizeof(PS5_BUTTONS[0])) return -1;
+    const int8_t index = legacyButtonValues(b);
+    if ((uint8_t) index >= (sizeof(PS5_BUTTONS) / sizeof(PS5_BUTTONS[0]))) return -1;
     return index;
 }
 

--- a/PS5Parser.cpp
+++ b/PS5Parser.cpp
@@ -36,8 +36,10 @@ enum DPADEnum {
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS5 Controller
 
-inline constexpr int8_t PS5Parser::getButtonIndex(ButtonEnum b) {
-        return (uint8_t) legacyButtonValues(b) >= (sizeof(PS5_BUTTONS) / sizeof(PS5_BUTTONS[0])) ? -1 : legacyButtonValues(b);
+int8_t PS5Parser::getButtonIndex(ButtonEnum b) {
+    const int8_t index = legacyButtonValues(b);
+    if ((uint8_t) index >= (sizeof(PS5_BUTTONS) / sizeof(PS5_BUTTONS[0]))) return -1;
+    return index;
 }
 
 bool PS5Parser::checkDpad(ButtonEnum b) {

--- a/PS5Parser.h
+++ b/PS5Parser.h
@@ -403,7 +403,7 @@ protected:
 
 
 private:
-        static int8_t getButtonIndex(ButtonEnum b);
+        static int8_t getButtonIndexPS5(ButtonEnum b);
         bool checkDpad(ButtonEnum b); // Used to check PS5 DPAD buttons
 
         PS5Data ps5Data;

--- a/PS5Parser.h
+++ b/PS5Parser.h
@@ -403,7 +403,7 @@ protected:
 
 
 private:
-        static int8_t getButtonIndex(ButtonEnum b);
+        static inline constexpr int8_t getButtonIndex(ButtonEnum b);
         bool checkDpad(ButtonEnum b); // Used to check PS5 DPAD buttons
 
         PS5Data ps5Data;

--- a/PS5Parser.h
+++ b/PS5Parser.h
@@ -403,7 +403,7 @@ protected:
 
 
 private:
-        static inline constexpr int8_t getButtonIndex(ButtonEnum b);
+        static int8_t getButtonIndex(ButtonEnum b);
         bool checkDpad(ButtonEnum b); // Used to check PS5 DPAD buttons
 
         PS5Data ps5Data;

--- a/PS5Parser.h
+++ b/PS5Parser.h
@@ -403,6 +403,7 @@ protected:
 
 
 private:
+        static int8_t getButtonIndex(ButtonEnum b);
         bool checkDpad(ButtonEnum b); // Used to check PS5 DPAD buttons
 
         PS5Data ps5Data;

--- a/PSBuzz.cpp
+++ b/PSBuzz.cpp
@@ -49,12 +49,20 @@ uint8_t PSBuzz::OnInitSuccessful() {
         return 0;
 };
 
+int8_t PSBuzz::getButtonIndex(ButtonEnum b) {
+    const uint8_t index = legacyButtonValues(b);
+    if (index > 4) return -1;  // 5 buttons, 0-4 inclusive
+    return index;
+}
+
 bool PSBuzz::getButtonPress(ButtonEnum b, uint8_t controller) {
-        return psbuzzButtons.val & (1UL << (b + 5 * controller)); // Each controller uses 5 bits, so the value is shifted 5 for each controller
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        return psbuzzButtons.val & (1UL << (index + 5 * controller)); // Each controller uses 5 bits, so the value is shifted 5 for each controller
 };
 
 bool PSBuzz::getButtonClick(ButtonEnum b, uint8_t controller) {
-        uint32_t mask = (1UL << (b + 5 * controller)); // Each controller uses 5 bits, so the value is shifted 5 for each controller
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        uint32_t mask = (1UL << (index + 5 * controller)); // Each controller uses 5 bits, so the value is shifted 5 for each controller
         bool click = buttonClickState.val & mask;
         buttonClickState.val &= ~mask; // Clear "click" event
         return click;

--- a/PSBuzz.cpp
+++ b/PSBuzz.cpp
@@ -49,19 +49,19 @@ uint8_t PSBuzz::OnInitSuccessful() {
         return 0;
 };
 
-int8_t PSBuzz::getButtonIndex(ButtonEnum b) {
-    const int8_t index = legacyButtonValues(b);
+int8_t PSBuzz::getButtonIndexBuzz(ButtonEnum b) {
+    const int8_t index = ButtonIndex(b);
     if (index > 4) return -1;  // 5 buttons, 0-4 inclusive
     return index;
 }
 
 bool PSBuzz::getButtonPress(ButtonEnum b, uint8_t controller) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexBuzz(b); if (index < 0) return 0;
         return psbuzzButtons.val & (1UL << (index + 5 * controller)); // Each controller uses 5 bits, so the value is shifted 5 for each controller
 };
 
 bool PSBuzz::getButtonClick(ButtonEnum b, uint8_t controller) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        const int8_t index = getButtonIndexBuzz(b); if (index < 0) return 0;
         uint32_t mask = (1UL << (index + 5 * controller)); // Each controller uses 5 bits, so the value is shifted 5 for each controller
         bool click = buttonClickState.val & mask;
         buttonClickState.val &= ~mask; // Clear "click" event

--- a/PSBuzz.cpp
+++ b/PSBuzz.cpp
@@ -50,7 +50,7 @@ uint8_t PSBuzz::OnInitSuccessful() {
 };
 
 int8_t PSBuzz::getButtonIndex(ButtonEnum b) {
-    const uint8_t index = legacyButtonValues(b);
+    const int8_t index = legacyButtonValues(b);
     if (index > 4) return -1;  // 5 buttons, 0-4 inclusive
     return index;
 }

--- a/PSBuzz.h
+++ b/PSBuzz.h
@@ -177,6 +177,7 @@ protected:
 private:
         void (*pFuncOnInit)(void); // Pointer to function called in onInit()
 
+        static int8_t getButtonIndex(ButtonEnum b);
         void PSBuzz_Command(uint8_t *data, uint16_t nbytes);
 
         PSBUZZButtons psbuzzButtons, oldButtonState, buttonClickState;

--- a/PSBuzz.h
+++ b/PSBuzz.h
@@ -175,9 +175,10 @@ protected:
         /**@}*/
 
 private:
+        static int8_t getButtonIndexBuzz(ButtonEnum b);
+
         void (*pFuncOnInit)(void); // Pointer to function called in onInit()
 
-        static int8_t getButtonIndex(ButtonEnum b);
         void PSBuzz_Command(uint8_t *data, uint16_t nbytes);
 
         PSBUZZButtons psbuzzButtons, oldButtonState, buttonClickState;

--- a/Wii.cpp
+++ b/Wii.cpp
@@ -1094,19 +1094,39 @@ void WII::readWiiBalanceBoardCalibration() {
 /*                    WII Commands                          */
 /************************************************************/
 
+int8_t WII::getButtonIndex(ButtonEnum b) {
+        const uint8_t index = legacyButtonValues(b);
+        if (index >= sizeof(WII_BUTTONS) / sizeof(WII_BUTTONS[0])) return -1;
+        return index;
+}
+
+int8_t WII::getButtonIndexPro(ButtonEnum b) {
+        const uint8_t index = legacyButtonValues(b);
+        if (index >= sizeof(WII_PROCONTROLLER_BUTTONS) / sizeof(WII_PROCONTROLLER_BUTTONS[0])) return -1;
+        return index;
+}
+
 bool WII::getButtonPress(ButtonEnum b) { // Return true when a button is pressed
-        if(wiiUProControllerConnected)
-                return (ButtonState & pgm_read_dword(&WII_PROCONTROLLER_BUTTONS[(uint8_t)b]));
-        else
-                return (ButtonState & pgm_read_dword(&WII_BUTTONS[(uint8_t)b]));
+        if (wiiUProControllerConnected) {
+                const int8_t index = getButtonIndexPro(b); if (index < 0) return 0;
+                return (ButtonState & pgm_read_dword(&WII_PROCONTROLLER_BUTTONS[index]));
+        }
+        else {
+                const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+                return (ButtonState & pgm_read_dword(&WII_BUTTONS[index]));
+        }
 }
 
 bool WII::getButtonClick(ButtonEnum b) { // Only return true when a button is clicked
         uint32_t button;
-        if(wiiUProControllerConnected)
-                button = pgm_read_dword(&WII_PROCONTROLLER_BUTTONS[(uint8_t)b]);
-        else
-                button = pgm_read_dword(&WII_BUTTONS[(uint8_t)b]);
+        if (wiiUProControllerConnected) {
+                const int8_t index = getButtonIndexPro(b); if (index < 0) return 0;
+                button = pgm_read_dword(&WII_PROCONTROLLER_BUTTONS[index]);
+        }
+        else {
+                const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+                button = pgm_read_dword(&WII_BUTTONS[index]);
+        }
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // clear "click" event
         return click;

--- a/Wii.cpp
+++ b/Wii.cpp
@@ -1094,16 +1094,12 @@ void WII::readWiiBalanceBoardCalibration() {
 /*                    WII Commands                          */
 /************************************************************/
 
-int8_t WII::getButtonIndex(ButtonEnum b) {
-        const int8_t index = legacyButtonValues(b);
-        if ((uint8_t) index >= (sizeof(WII_BUTTONS) / sizeof(WII_BUTTONS[0]))) return -1;
-        return index;
+inline constexpr int8_t WII::getButtonIndex(ButtonEnum b) {
+        return (uint8_t)legacyButtonValues(b) >= (sizeof(WII_BUTTONS) / sizeof(WII_BUTTONS[0])) ? -1 : legacyButtonValues(b);
 }
 
-int8_t WII::getButtonIndexPro(ButtonEnum b) {
-        const int8_t index = legacyButtonValues(b);
-        if ((uint8_t) index >= (sizeof(WII_PROCONTROLLER_BUTTONS) / sizeof(WII_PROCONTROLLER_BUTTONS[0]))) return -1;
-        return index;
+inline constexpr int8_t WII::getButtonIndexPro(ButtonEnum b) {
+        return (uint8_t)legacyButtonValues(b) >= (sizeof(WII_PROCONTROLLER_BUTTONS) / sizeof(WII_PROCONTROLLER_BUTTONS[0])) ? -1 : legacyButtonValues(b);
 }
 
 bool WII::getButtonPress(ButtonEnum b) { // Return true when a button is pressed

--- a/Wii.cpp
+++ b/Wii.cpp
@@ -1095,14 +1095,14 @@ void WII::readWiiBalanceBoardCalibration() {
 /************************************************************/
 
 int8_t WII::getButtonIndex(ButtonEnum b) {
-        const uint8_t index = legacyButtonValues(b);
-        if (index >= sizeof(WII_BUTTONS) / sizeof(WII_BUTTONS[0])) return -1;
+        const int8_t index = legacyButtonValues(b);
+        if ((uint8_t) index >= (sizeof(WII_BUTTONS) / sizeof(WII_BUTTONS[0]))) return -1;
         return index;
 }
 
 int8_t WII::getButtonIndexPro(ButtonEnum b) {
-        const uint8_t index = legacyButtonValues(b);
-        if (index >= sizeof(WII_PROCONTROLLER_BUTTONS) / sizeof(WII_PROCONTROLLER_BUTTONS[0])) return -1;
+        const int8_t index = legacyButtonValues(b);
+        if ((uint8_t) index >= (sizeof(WII_PROCONTROLLER_BUTTONS) / sizeof(WII_PROCONTROLLER_BUTTONS[0]))) return -1;
         return index;
 }
 

--- a/Wii.cpp
+++ b/Wii.cpp
@@ -1094,25 +1094,25 @@ void WII::readWiiBalanceBoardCalibration() {
 /*                    WII Commands                          */
 /************************************************************/
 
-int8_t WII::getButtonIndex(ButtonEnum b) {
-        const int8_t index = legacyButtonValues(b);
+int8_t WII::getButtonIndexWii(ButtonEnum b) {
+        const int8_t index = ButtonIndex(b);
         if ((uint8_t) index >= (sizeof(WII_BUTTONS) / sizeof(WII_BUTTONS[0]))) return -1;
         return index;
 }
 
-int8_t WII::getButtonIndexPro(ButtonEnum b) {
-        const int8_t index = legacyButtonValues(b);
+int8_t WII::getButtonIndexWiiPro(ButtonEnum b) {
+        const int8_t index = ButtonIndex(b);
         if ((uint8_t) index >= (sizeof(WII_PROCONTROLLER_BUTTONS) / sizeof(WII_PROCONTROLLER_BUTTONS[0]))) return -1;
         return index;
 }
 
 bool WII::getButtonPress(ButtonEnum b) { // Return true when a button is pressed
         if (wiiUProControllerConnected) {
-                const int8_t index = getButtonIndexPro(b); if (index < 0) return 0;
+                const int8_t index = getButtonIndexWiiPro(b); if (index < 0) return 0;
                 return (ButtonState & pgm_read_dword(&WII_PROCONTROLLER_BUTTONS[index]));
         }
         else {
-                const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+                const int8_t index = getButtonIndexWii(b); if (index < 0) return 0;
                 return (ButtonState & pgm_read_dword(&WII_BUTTONS[index]));
         }
 }
@@ -1120,11 +1120,11 @@ bool WII::getButtonPress(ButtonEnum b) { // Return true when a button is pressed
 bool WII::getButtonClick(ButtonEnum b) { // Only return true when a button is clicked
         uint32_t button;
         if (wiiUProControllerConnected) {
-                const int8_t index = getButtonIndexPro(b); if (index < 0) return 0;
+                const int8_t index = getButtonIndexWiiPro(b); if (index < 0) return 0;
                 button = pgm_read_dword(&WII_PROCONTROLLER_BUTTONS[index]);
         }
         else {
-                const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+                const int8_t index = getButtonIndexWii(b); if (index < 0) return 0;
                 button = pgm_read_dword(&WII_BUTTONS[index]);
         }
         bool click = (ButtonClickState & button);

--- a/Wii.cpp
+++ b/Wii.cpp
@@ -1094,12 +1094,16 @@ void WII::readWiiBalanceBoardCalibration() {
 /*                    WII Commands                          */
 /************************************************************/
 
-inline constexpr int8_t WII::getButtonIndex(ButtonEnum b) {
-        return (uint8_t)legacyButtonValues(b) >= (sizeof(WII_BUTTONS) / sizeof(WII_BUTTONS[0])) ? -1 : legacyButtonValues(b);
+int8_t WII::getButtonIndex(ButtonEnum b) {
+        const int8_t index = legacyButtonValues(b);
+        if ((uint8_t) index >= (sizeof(WII_BUTTONS) / sizeof(WII_BUTTONS[0]))) return -1;
+        return index;
 }
 
-inline constexpr int8_t WII::getButtonIndexPro(ButtonEnum b) {
-        return (uint8_t)legacyButtonValues(b) >= (sizeof(WII_PROCONTROLLER_BUTTONS) / sizeof(WII_PROCONTROLLER_BUTTONS[0])) ? -1 : legacyButtonValues(b);
+int8_t WII::getButtonIndexPro(ButtonEnum b) {
+        const int8_t index = legacyButtonValues(b);
+        if ((uint8_t) index >= (sizeof(WII_PROCONTROLLER_BUTTONS) / sizeof(WII_PROCONTROLLER_BUTTONS[0]))) return -1;
+        return index;
 }
 
 bool WII::getButtonPress(ButtonEnum b) { // Return true when a button is pressed

--- a/Wii.h
+++ b/Wii.h
@@ -431,8 +431,8 @@ protected:
         /**@}*/
 
 private:
-        static int8_t getButtonIndex(ButtonEnum b);
-        static int8_t getButtonIndexPro(ButtonEnum b);
+        static int8_t getButtonIndexWii(ButtonEnum b);
+        static int8_t getButtonIndexWiiPro(ButtonEnum b);
 
         void L2CAP_task(); // L2CAP state machine
 

--- a/Wii.h
+++ b/Wii.h
@@ -431,8 +431,8 @@ protected:
         /**@}*/
 
 private:
-        static int8_t getButtonIndex(ButtonEnum b);
-        static int8_t getButtonIndexPro(ButtonEnum b);
+        static inline constexpr int8_t getButtonIndex(ButtonEnum b);
+        static inline constexpr int8_t getButtonIndexPro(ButtonEnum b);
 
         void L2CAP_task(); // L2CAP state machine
 

--- a/Wii.h
+++ b/Wii.h
@@ -431,6 +431,8 @@ protected:
         /**@}*/
 
 private:
+        static int8_t getButtonIndex(ButtonEnum b);
+        static int8_t getButtonIndexPro(ButtonEnum b);
 
         void L2CAP_task(); // L2CAP state machine
 

--- a/Wii.h
+++ b/Wii.h
@@ -431,8 +431,8 @@ protected:
         /**@}*/
 
 private:
-        static inline constexpr int8_t getButtonIndex(ButtonEnum b);
-        static inline constexpr int8_t getButtonIndexPro(ButtonEnum b);
+        static int8_t getButtonIndex(ButtonEnum b);
+        static int8_t getButtonIndexPro(ButtonEnum b);
 
         void L2CAP_task(); // L2CAP state machine
 

--- a/XBOXOLD.cpp
+++ b/XBOXOLD.cpp
@@ -20,6 +20,30 @@
 //#define EXTRADEBUG // Uncomment to get even more debugging data
 //#define PRINTREPORT // Uncomment to print the report send by the Xbox controller
 
+/** Buttons on the controllers */
+const uint8_t XBOXOLD_BUTTONS[] PROGMEM = {
+        0x01, // UP
+        0x08, // RIGHT
+        0x02, // DOWN
+        0x04, // LEFT
+
+        0x20, // BACK
+        0x10, // START
+        0x40, // L3
+        0x80, // R3
+
+        // A, B, X, Y, BLACK, WHITE, L1, and R1 are analog buttons
+        4, // BLACK
+        5, // WHTIE
+        6, // L1
+        7, // R1
+
+        1, // B
+        0, // A
+        2, // X
+        3, // Y
+};
+
 
 XBOXOLD::XBOXOLD(USB *p) :
 pUsb(p), // pointer to USB class instance - mandatory
@@ -270,74 +294,55 @@ void XBOXOLD::printReport(uint16_t length __attribute__((unused))) { //Uncomment
 }
 
 int8_t XBOXOLD::getAnalogIndex(ButtonEnum b) {
-        // A, B, X, Y, BLACK, WHITE, L, and R are analog buttons
-        uint8_t out;
+        // A, B, X, Y, BLACK, WHITE, L1, and R1 are analog buttons
+        const int8_t index = ButtonIndex(b);
 
-        switch (b) {
-        case A:
-                out = 0; break;
-        case B:
-                out = 1; break;
-        case X:
-                out = 2; break;
-        case Y:
-                out = 3; break;
-        case WHITE:
-                out = 5; break;
-        case BLACK:
-                out = 4; break;
-        case L:
-        case L1:
-        case L2:
-                out = 6; break;
-        case R:
-        case R1:
-        case R2:
-                out = 7; break;
-        default:
-                out = -1; break;
+        switch (index) {
+        case ButtonIndex(A):
+        case ButtonIndex(B):
+        case ButtonIndex(X):
+        case ButtonIndex(Y):
+        case ButtonIndex(BLACK):
+        case ButtonIndex(WHITE):
+        case ButtonIndex(L1):
+        case ButtonIndex(R1):
+                return index;
+        default: break;
         }
 
-        return out;
+        return -1;
 }
 
-int8_t XBOXOLD::getDigitalOffset(ButtonEnum b) {
+int8_t XBOXOLD::getDigitalIndex(ButtonEnum b) {
         // UP, DOWN, LEFT, RIGHT, START, BACK, L3, and R3 are digital buttons
-        // (these are offets for the bitshift)
-        uint8_t out;
+        const int8_t index = ButtonIndex(b);
 
-        switch (b) {
-        case UP:
-                out = 0; break;
-        case DOWN:
-                out = 1; break;
-        case LEFT:
-                out = 2; break;
-        case RIGHT:
-                out = 3; break;
-        case START:
-                out = 4; break;
-        case BACK:
-                out = 5; break;
-        case L3:
-                out = 6; break;
-        case R3:
-                out = 7; break;
-        default:
-                out = -1; break;
+        switch (index) {
+        case ButtonIndex(UP):
+        case ButtonIndex(DOWN):
+        case ButtonIndex(LEFT):
+        case ButtonIndex(RIGHT):
+        case ButtonIndex(START):
+        case ButtonIndex(BACK):
+        case ButtonIndex(L3):
+        case ButtonIndex(R3):
+                return index;
+        default: break;
         }
 
-        return out;
+        return -1;
 }
 
 uint8_t XBOXOLD::getButtonPress(ButtonEnum b) {
         const int8_t analogIndex = getAnalogIndex(b);
         if (analogIndex >= 0) {
-                return buttonValues[analogIndex];
+                const uint8_t buttonIndex = pgm_read_byte(&XBOXOLD_BUTTONS[analogIndex]);
+                return buttonValues[buttonIndex];
         }
-        const int8_t digitalOffset = getDigitalOffset(b);
-        if (digitalOffset >= 0) {
-                return (ButtonState & (1 << digitalOffset));
+        const int8_t digitalIndex = getDigitalIndex(b);
+        if (digitalIndex >= 0) {
+                const uint8_t buttonMask = pgm_read_byte(&XBOXOLD_BUTTONS[digitalIndex]);
+                return (ButtonState & buttonMask);
         }
         return 0;
 }
@@ -345,15 +350,16 @@ uint8_t XBOXOLD::getButtonPress(ButtonEnum b) {
 bool XBOXOLD::getButtonClick(ButtonEnum b) {
         const int8_t analogIndex = getAnalogIndex(b);
         if (analogIndex >= 0) {
-                if (buttonClicked[analogIndex]) {
-                        buttonClicked[analogIndex] = false;
+                const uint8_t buttonIndex = pgm_read_byte(&XBOXOLD_BUTTONS[analogIndex]);
+                if (buttonClicked[buttonIndex]) {
+                        buttonClicked[buttonIndex] = false;
                         return true;
                 }
                 return false;
         }
-        const int8_t digitalOffset = getDigitalOffset(b);
-        if (digitalOffset >= 0) {
-                const uint8_t mask = (1 << digitalOffset);
+        const int8_t digitalIndex = getDigitalIndex(b);
+        if (digitalIndex >= 0) {
+                const uint8_t mask = pgm_read_byte(&XBOXOLD_BUTTONS[digitalIndex]);
                 const bool click = (ButtonClickState & mask);
                 ButtonClickState &= ~mask;
                 return click;

--- a/XBOXOLD.cpp
+++ b/XBOXOLD.cpp
@@ -44,7 +44,6 @@ const uint8_t XBOXOLD_BUTTONS[] PROGMEM = {
         3, // Y
 };
 
-
 XBOXOLD::XBOXOLD(USB *p) :
 pUsb(p), // pointer to USB class instance - mandatory
 bAddress(0), // device address - mandatory

--- a/XBOXOLD.h
+++ b/XBOXOLD.h
@@ -154,7 +154,7 @@ protected:
 
 private:
         static int8_t getAnalogIndex(ButtonEnum b);
-        static int8_t getDigitalOffset(ButtonEnum b);
+        static int8_t getDigitalIndex(ButtonEnum b);
 
         /**
          * Called when the controller is successfully initialized.

--- a/XBOXOLD.h
+++ b/XBOXOLD.h
@@ -153,6 +153,9 @@ protected:
         EpInfo epInfo[XBOX_MAX_ENDPOINTS];
 
 private:
+        static int8_t getAnalogIndex(ButtonEnum b);
+        static int8_t getDigitalOffset(ButtonEnum b);
+
         /**
          * Called when the controller is successfully initialized.
          * Use attachOnInit(void (*funcOnInit)(void)) to call your own function.

--- a/XBOXONE.cpp
+++ b/XBOXONE.cpp
@@ -331,9 +331,9 @@ void XBOXONE::readReport() {
         if(readBuf[0] == 0x07) {
                 // The XBOX button has a separate message
                 if(readBuf[4] == 1)
-                        ButtonState |= pgm_read_word(&XBOX_BUTTONS[legacyButtonValues(XBOX)]);
+                        ButtonState |= pgm_read_word(&XBOX_BUTTONS[ButtonIndex(XBOX)]);
                 else
-                        ButtonState &= ~pgm_read_word(&XBOX_BUTTONS[legacyButtonValues(XBOX)]);
+                        ButtonState &= ~pgm_read_word(&XBOX_BUTTONS[ButtonIndex(XBOX)]);
 
                 if(ButtonState != OldButtonState) {
                     ButtonClickState = ButtonState & ~OldButtonState; // Update click state variable
@@ -348,7 +348,7 @@ void XBOXONE::readReport() {
                 return;
         }
 
-        uint16_t xbox = ButtonState & pgm_read_word(&XBOX_BUTTONS[legacyButtonValues(XBOX)]); // Since the XBOX button is separate, save it and add it back in
+        uint16_t xbox = ButtonState & pgm_read_word(&XBOX_BUTTONS[ButtonIndex(XBOX)]); // Since the XBOX button is separate, save it and add it back in
         // xbox button from before, dpad, abxy, start/back, sync, stick click, shoulder buttons
         ButtonState = xbox | (((uint16_t)readBuf[5] & 0xF) << 8) | (readBuf[4] & 0xF0)  | (((uint16_t)readBuf[4] & 0x0C) << 10) | ((readBuf[4] & 0x01) << 3) | (((uint16_t)readBuf[5] & 0xC0) << 8) | ((readBuf[5] & 0x30) >> 4);
 
@@ -378,23 +378,23 @@ void XBOXONE::readReport() {
 }
 
 uint16_t XBOXONE::getButtonPress(ButtonEnum b) {
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
-        if(index == legacyButtonValues(L2)) // These are analog buttons
+        const int8_t index = getButtonIndexXbox(b); if (index < 0) return 0;
+        if(index == ButtonIndex(L2)) // These are analog buttons
                 return triggerValue[0];
-        else if(index == legacyButtonValues(R2))
+        else if(index == ButtonIndex(R2))
                 return triggerValue[1];
         return (bool)(ButtonState & ((uint16_t)pgm_read_word(&XBOX_BUTTONS[index])));
 }
 
 bool XBOXONE::getButtonClick(ButtonEnum b) {
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
-        if(index == legacyButtonValues(L2)) {
+        const int8_t index = getButtonIndexXbox(b); if (index < 0) return 0;
+        if(index == ButtonIndex(L2)) {
                 if(L2Clicked) {
                         L2Clicked = false;
                         return true;
                 }
                 return false;
-        } else if(index == legacyButtonValues(R2)) {
+        } else if(index == ButtonIndex(R2)) {
                 if(R2Clicked) {
                         R2Clicked = false;
                         return true;

--- a/XBOXONE.cpp
+++ b/XBOXONE.cpp
@@ -378,29 +378,29 @@ void XBOXONE::readReport() {
 }
 
 uint16_t XBOXONE::getButtonPress(ButtonEnum b) {
-        if(b == L2) // These are analog buttons
-                return triggerValue[0];
-        else if(b == R2)
-                return triggerValue[1];
         const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        if(index == legacyButtonValues(L2)) // These are analog buttons
+                return triggerValue[0];
+        else if(index == legacyButtonValues(R2))
+                return triggerValue[1];
         return (bool)(ButtonState & ((uint16_t)pgm_read_word(&XBOX_BUTTONS[index])));
 }
 
 bool XBOXONE::getButtonClick(ButtonEnum b) {
-        if(b == L2) {
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        if(index == legacyButtonValues(L2)) {
                 if(L2Clicked) {
                         L2Clicked = false;
                         return true;
                 }
                 return false;
-        } else if(b == R2) {
+        } else if(index == legacyButtonValues(R2)) {
                 if(R2Clicked) {
                         R2Clicked = false;
                         return true;
                 }
                 return false;
         }
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
         uint16_t button = pgm_read_word(&XBOX_BUTTONS[index]);
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // Clear "click" event

--- a/XBOXONE.cpp
+++ b/XBOXONE.cpp
@@ -331,9 +331,9 @@ void XBOXONE::readReport() {
         if(readBuf[0] == 0x07) {
                 // The XBOX button has a separate message
                 if(readBuf[4] == 1)
-                        ButtonState |= pgm_read_word(&XBOX_BUTTONS[XBOX]);
+                        ButtonState |= pgm_read_word(&XBOX_BUTTONS[legacyButtonValues(XBOX)]);
                 else
-                        ButtonState &= ~pgm_read_word(&XBOX_BUTTONS[XBOX]);
+                        ButtonState &= ~pgm_read_word(&XBOX_BUTTONS[legacyButtonValues(XBOX)]);
 
                 if(ButtonState != OldButtonState) {
                     ButtonClickState = ButtonState & ~OldButtonState; // Update click state variable
@@ -348,7 +348,7 @@ void XBOXONE::readReport() {
                 return;
         }
 
-        uint16_t xbox = ButtonState & pgm_read_word(&XBOX_BUTTONS[XBOX]); // Since the XBOX button is separate, save it and add it back in
+        uint16_t xbox = ButtonState & pgm_read_word(&XBOX_BUTTONS[legacyButtonValues(XBOX)]); // Since the XBOX button is separate, save it and add it back in
         // xbox button from before, dpad, abxy, start/back, sync, stick click, shoulder buttons
         ButtonState = xbox | (((uint16_t)readBuf[5] & 0xF) << 8) | (readBuf[4] & 0xF0)  | (((uint16_t)readBuf[4] & 0x0C) << 10) | ((readBuf[4] & 0x01) << 3) | (((uint16_t)readBuf[5] & 0xC0) << 8) | ((readBuf[5] & 0x30) >> 4);
 
@@ -382,7 +382,8 @@ uint16_t XBOXONE::getButtonPress(ButtonEnum b) {
                 return triggerValue[0];
         else if(b == R2)
                 return triggerValue[1];
-        return (bool)(ButtonState & ((uint16_t)pgm_read_word(&XBOX_BUTTONS[(uint8_t)b])));
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        return (bool)(ButtonState & ((uint16_t)pgm_read_word(&XBOX_BUTTONS[index])));
 }
 
 bool XBOXONE::getButtonClick(ButtonEnum b) {
@@ -399,7 +400,8 @@ bool XBOXONE::getButtonClick(ButtonEnum b) {
                 }
                 return false;
         }
-        uint16_t button = pgm_read_word(&XBOX_BUTTONS[(uint8_t)b]);
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        uint16_t button = pgm_read_word(&XBOX_BUTTONS[index]);
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // Clear "click" event
         return click;

--- a/XBOXONESParser.cpp
+++ b/XBOXONESParser.cpp
@@ -54,8 +54,8 @@ enum DPADEnum {
         DPAD_LEFT_UP = 0x8,
 };
 
-int8_t XBOXONESParser::getButtonIndex(ButtonEnum b) {
-        const int8_t index = legacyButtonValues(b);
+int8_t XBOXONESParser::getButtonIndexXboxOneS(ButtonEnum b) {
+        const int8_t index = ButtonIndex(b);
         if ((uint8_t) index >= (sizeof(XBOX_ONE_S_BUTTONS) / sizeof(XBOX_ONE_S_BUTTONS[0]))) return -1;
         return index;
 }
@@ -76,33 +76,33 @@ bool XBOXONESParser::checkDpad(ButtonEnum b) {
 }
 
 uint16_t XBOXONESParser::getButtonPress(ButtonEnum b) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
-        if (index == legacyButtonValues(L2))
+        const int8_t index = getButtonIndexXboxOneS(b); if (index < 0) return 0;
+        if (index == ButtonIndex(L2))
                 return xboxOneSData.trigger[0];
-        else if (index == legacyButtonValues(R2))
+        else if (index == ButtonIndex(R2))
                 return xboxOneSData.trigger[1];
         else if (index <= LEFT) // Dpad
                 return checkDpad(b);
-        else if (index == legacyButtonValues(XBOX))
+        else if (index == ButtonIndex(XBOX))
                 return xboxButtonState;
         return xboxOneSData.btn.val & (1UL << pgm_read_byte(&XBOX_ONE_S_BUTTONS[index]));
 }
 
 bool XBOXONESParser::getButtonClick(ButtonEnum b) {
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
-        if(index == legacyButtonValues(L2)) {
+        const int8_t index = getButtonIndexXboxOneS(b); if (index < 0) return 0;
+        if(index == ButtonIndex(L2)) {
                 if(L2Clicked) {
                         L2Clicked = false;
                         return true;
                 }
                 return false;
-        } else if(index == legacyButtonValues(R2)) {
+        } else if(index == ButtonIndex(R2)) {
                 if(R2Clicked) {
                         R2Clicked = false;
                         return true;
                 }
                 return false;
-        } else if (index == legacyButtonValues(XBOX)) {
+        } else if (index == ButtonIndex(XBOX)) {
                 bool click = xboxbuttonClickState;
                 xboxbuttonClickState = 0; // Clear "click" event
                 return click;

--- a/XBOXONESParser.cpp
+++ b/XBOXONESParser.cpp
@@ -76,37 +76,37 @@ bool XBOXONESParser::checkDpad(ButtonEnum b) {
 }
 
 uint16_t XBOXONESParser::getButtonPress(ButtonEnum b) {
-        if (b == L2)
-                return xboxOneSData.trigger[0];
-        else if (b == R2)
-                return xboxOneSData.trigger[1];
-        else if (b <= LEFT) // Dpad
-                return checkDpad(b);
-        else if (b == XBOX)
-                return xboxButtonState;
         const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        if (index == legacyButtonValues(L2))
+                return xboxOneSData.trigger[0];
+        else if (index == legacyButtonValues(R2))
+                return xboxOneSData.trigger[1];
+        else if (index <= LEFT) // Dpad
+                return checkDpad(b);
+        else if (index == legacyButtonValues(XBOX))
+                return xboxButtonState;
         return xboxOneSData.btn.val & (1UL << pgm_read_byte(&XBOX_ONE_S_BUTTONS[index]));
 }
 
 bool XBOXONESParser::getButtonClick(ButtonEnum b) {
-        if(b == L2) {
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        if(index == legacyButtonValues(L2)) {
                 if(L2Clicked) {
                         L2Clicked = false;
                         return true;
                 }
                 return false;
-        } else if(b == R2) {
+        } else if(index == legacyButtonValues(R2)) {
                 if(R2Clicked) {
                         R2Clicked = false;
                         return true;
                 }
                 return false;
-        } else if (b == XBOX) {
+        } else if (index == legacyButtonValues(XBOX)) {
                 bool click = xboxbuttonClickState;
                 xboxbuttonClickState = 0; // Clear "click" event
                 return click;
         }
-        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
         uint32_t mask = 1UL << pgm_read_byte(&XBOX_ONE_S_BUTTONS[index]);
         bool click = buttonClickState.val & mask;
         buttonClickState.val &= ~mask; // Clear "click" event

--- a/XBOXONESParser.cpp
+++ b/XBOXONESParser.cpp
@@ -55,8 +55,8 @@ enum DPADEnum {
 };
 
 int8_t XBOXONESParser::getButtonIndex(ButtonEnum b) {
-        const uint8_t index = legacyButtonValues(b);
-        if (index >= sizeof(XBOX_ONE_S_BUTTONS) / sizeof(XBOX_ONE_S_BUTTONS[0])) return -1;
+        const int8_t index = legacyButtonValues(b);
+        if ((uint8_t) index >= (sizeof(XBOX_ONE_S_BUTTONS) / sizeof(XBOX_ONE_S_BUTTONS[0]))) return -1;
         return index;
 }
 

--- a/XBOXONESParser.cpp
+++ b/XBOXONESParser.cpp
@@ -54,6 +54,12 @@ enum DPADEnum {
         DPAD_LEFT_UP = 0x8,
 };
 
+int8_t XBOXONESParser::getButtonIndex(ButtonEnum b) {
+        const uint8_t index = legacyButtonValues(b);
+        if (index >= sizeof(XBOX_ONE_S_BUTTONS) / sizeof(XBOX_ONE_S_BUTTONS[0])) return -1;
+        return index;
+}
+
 bool XBOXONESParser::checkDpad(ButtonEnum b) {
         switch (b) {
                 case UP:
@@ -78,7 +84,8 @@ uint16_t XBOXONESParser::getButtonPress(ButtonEnum b) {
                 return checkDpad(b);
         else if (b == XBOX)
                 return xboxButtonState;
-        return xboxOneSData.btn.val & (1UL << pgm_read_byte(&XBOX_ONE_S_BUTTONS[(uint8_t)b]));
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        return xboxOneSData.btn.val & (1UL << pgm_read_byte(&XBOX_ONE_S_BUTTONS[index]));
 }
 
 bool XBOXONESParser::getButtonClick(ButtonEnum b) {
@@ -99,7 +106,8 @@ bool XBOXONESParser::getButtonClick(ButtonEnum b) {
                 xboxbuttonClickState = 0; // Clear "click" event
                 return click;
         }
-        uint32_t mask = 1UL << pgm_read_byte(&XBOX_ONE_S_BUTTONS[(uint8_t)b]);
+        const int8_t index = getButtonIndex(b); if (index < 0) return 0;
+        uint32_t mask = 1UL << pgm_read_byte(&XBOX_ONE_S_BUTTONS[index]);
         bool click = buttonClickState.val & mask;
         buttonClickState.val &= ~mask; // Clear "click" event
         return click;

--- a/XBOXONESParser.cpp
+++ b/XBOXONESParser.cpp
@@ -54,8 +54,10 @@ enum DPADEnum {
         DPAD_LEFT_UP = 0x8,
 };
 
-inline constexpr int8_t XBOXONESParser::getButtonIndex(ButtonEnum b) {
-        return (uint8_t) legacyButtonValues(b) >= (sizeof(XBOX_ONE_S_BUTTONS) / sizeof(XBOX_ONE_S_BUTTONS[0])) ? -1 : legacyButtonValues(b);
+int8_t XBOXONESParser::getButtonIndex(ButtonEnum b) {
+        const int8_t index = legacyButtonValues(b);
+        if ((uint8_t) index >= (sizeof(XBOX_ONE_S_BUTTONS) / sizeof(XBOX_ONE_S_BUTTONS[0]))) return -1;
+        return index;
 }
 
 bool XBOXONESParser::checkDpad(ButtonEnum b) {

--- a/XBOXONESParser.cpp
+++ b/XBOXONESParser.cpp
@@ -54,10 +54,8 @@ enum DPADEnum {
         DPAD_LEFT_UP = 0x8,
 };
 
-int8_t XBOXONESParser::getButtonIndex(ButtonEnum b) {
-        const int8_t index = legacyButtonValues(b);
-        if ((uint8_t) index >= (sizeof(XBOX_ONE_S_BUTTONS) / sizeof(XBOX_ONE_S_BUTTONS[0]))) return -1;
-        return index;
+inline constexpr int8_t XBOXONESParser::getButtonIndex(ButtonEnum b) {
+        return (uint8_t) legacyButtonValues(b) >= (sizeof(XBOX_ONE_S_BUTTONS) / sizeof(XBOX_ONE_S_BUTTONS[0])) ? -1 : legacyButtonValues(b);
 }
 
 bool XBOXONESParser::checkDpad(ButtonEnum b) {

--- a/XBOXONESParser.h
+++ b/XBOXONESParser.h
@@ -111,7 +111,7 @@ protected:
         virtual void sendOutputReport(uint8_t *data, uint8_t nbytes) = 0;
 
 private:
-        static inline constexpr int8_t getButtonIndex(ButtonEnum b);
+        static int8_t getButtonIndex(ButtonEnum b);
 
         bool checkDpad(ButtonEnum b); // Used to check Xbox One S DPAD buttons
 

--- a/XBOXONESParser.h
+++ b/XBOXONESParser.h
@@ -111,6 +111,8 @@ protected:
         virtual void sendOutputReport(uint8_t *data, uint8_t nbytes) = 0;
 
 private:
+        static int8_t getButtonIndex(ButtonEnum b);
+
         bool checkDpad(ButtonEnum b); // Used to check Xbox One S DPAD buttons
 
         XboxOneSData xboxOneSData;

--- a/XBOXONESParser.h
+++ b/XBOXONESParser.h
@@ -111,7 +111,7 @@ protected:
         virtual void sendOutputReport(uint8_t *data, uint8_t nbytes) = 0;
 
 private:
-        static int8_t getButtonIndex(ButtonEnum b);
+        static int8_t getButtonIndexXboxOneS(ButtonEnum b);
 
         bool checkDpad(ButtonEnum b); // Used to check Xbox One S DPAD buttons
 

--- a/XBOXONESParser.h
+++ b/XBOXONESParser.h
@@ -111,7 +111,7 @@ protected:
         virtual void sendOutputReport(uint8_t *data, uint8_t nbytes) = 0;
 
 private:
-        static int8_t getButtonIndex(ButtonEnum b);
+        static inline constexpr int8_t getButtonIndex(ButtonEnum b);
 
         bool checkDpad(ButtonEnum b); // Used to check Xbox One S DPAD buttons
 

--- a/XBOXRECV.cpp
+++ b/XBOXRECV.cpp
@@ -412,7 +412,8 @@ uint8_t XBOXRECV::getButtonPress(ButtonEnum b, uint8_t controller) {
                 return (uint8_t)(ButtonState[controller] >> 8);
         else if(b == R2)
                 return (uint8_t)ButtonState[controller];
-        return (bool)(ButtonState[controller] & ((uint32_t)pgm_read_word(&XBOX_BUTTONS[(uint8_t)b]) << 16));
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        return (bool)(ButtonState[controller] & ((uint32_t)pgm_read_word(&XBOX_BUTTONS[index]) << 16));
 }
 
 bool XBOXRECV::getButtonClick(ButtonEnum b, uint8_t controller) {
@@ -429,7 +430,8 @@ bool XBOXRECV::getButtonClick(ButtonEnum b, uint8_t controller) {
                 }
                 return false;
         }
-        uint16_t button = pgm_read_word(&XBOX_BUTTONS[(uint8_t)b]);
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        uint16_t button = pgm_read_word(&XBOX_BUTTONS[index]);
         bool click = (ButtonClickState[controller] & button);
         ButtonClickState[controller] &= ~button; // clear "click" event
         return click;

--- a/XBOXRECV.cpp
+++ b/XBOXRECV.cpp
@@ -408,29 +408,29 @@ void XBOXRECV::printReport(uint8_t controller __attribute__((unused)), uint8_t n
 }
 
 uint8_t XBOXRECV::getButtonPress(ButtonEnum b, uint8_t controller) {
-        if(b == L2) // These are analog buttons
-                return (uint8_t)(ButtonState[controller] >> 8);
-        else if(b == R2)
-                return (uint8_t)ButtonState[controller];
         const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        if(index == legacyButtonValues(L2)) // These are analog buttons
+                return (uint8_t)(ButtonState[controller] >> 8);
+        else if(index == legacyButtonValues(R2))
+                return (uint8_t)ButtonState[controller];
         return (bool)(ButtonState[controller] & ((uint32_t)pgm_read_word(&XBOX_BUTTONS[index]) << 16));
 }
 
 bool XBOXRECV::getButtonClick(ButtonEnum b, uint8_t controller) {
-        if(b == L2) {
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        if(index == legacyButtonValues(L2)) {
                 if(L2Clicked[controller]) {
                         L2Clicked[controller] = false;
                         return true;
                 }
                 return false;
-        } else if(b == R2) {
+        } else if(index == legacyButtonValues(R2)) {
                 if(R2Clicked[controller]) {
                         R2Clicked[controller] = false;
                         return true;
                 }
                 return false;
         }
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
         uint16_t button = pgm_read_word(&XBOX_BUTTONS[index]);
         bool click = (ButtonClickState[controller] & button);
         ButtonClickState[controller] &= ~button; // clear "click" event

--- a/XBOXRECV.cpp
+++ b/XBOXRECV.cpp
@@ -408,23 +408,23 @@ void XBOXRECV::printReport(uint8_t controller __attribute__((unused)), uint8_t n
 }
 
 uint8_t XBOXRECV::getButtonPress(ButtonEnum b, uint8_t controller) {
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
-        if(index == legacyButtonValues(L2)) // These are analog buttons
+        const int8_t index = getButtonIndexXbox(b); if (index < 0) return 0;
+        if(index == ButtonIndex(L2)) // These are analog buttons
                 return (uint8_t)(ButtonState[controller] >> 8);
-        else if(index == legacyButtonValues(R2))
+        else if(index == ButtonIndex(R2))
                 return (uint8_t)ButtonState[controller];
         return (bool)(ButtonState[controller] & ((uint32_t)pgm_read_word(&XBOX_BUTTONS[index]) << 16));
 }
 
 bool XBOXRECV::getButtonClick(ButtonEnum b, uint8_t controller) {
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
-        if(index == legacyButtonValues(L2)) {
+        const int8_t index = getButtonIndexXbox(b); if (index < 0) return 0;
+        if(index == ButtonIndex(L2)) {
                 if(L2Clicked[controller]) {
                         L2Clicked[controller] = false;
                         return true;
                 }
                 return false;
-        } else if(index == legacyButtonValues(R2)) {
+        } else if(index == ButtonIndex(R2)) {
                 if(R2Clicked[controller]) {
                         R2Clicked[controller] = false;
                         return true;

--- a/XBOXUSB.cpp
+++ b/XBOXUSB.cpp
@@ -281,23 +281,23 @@ void XBOXUSB::printReport() { //Uncomment "#define PRINTREPORT" to print the rep
 }
 
 uint8_t XBOXUSB::getButtonPress(ButtonEnum b) {
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
-        if(index == legacyButtonValues(L2)) // These are analog buttons
+        const int8_t index = getButtonIndexXbox(b); if (index < 0) return 0;
+        if(index == ButtonIndex(L2)) // These are analog buttons
                 return (uint8_t)(ButtonState >> 8);
-        else if(index == legacyButtonValues(R2))
+        else if(index == ButtonIndex(R2))
                 return (uint8_t)ButtonState;
         return (bool)(ButtonState & ((uint32_t)pgm_read_word(&XBOX_BUTTONS[index]) << 16));
 }
 
 bool XBOXUSB::getButtonClick(ButtonEnum b) {
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
-        if(index == legacyButtonValues(L2)) {
+        const int8_t index = getButtonIndexXbox(b); if (index < 0) return 0;
+        if(index == ButtonIndex(L2)) {
                 if(L2Clicked) {
                         L2Clicked = false;
                         return true;
                 }
                 return false;
-        } else if(index == legacyButtonValues(R2)) {
+        } else if(index == ButtonIndex(R2)) {
                 if(R2Clicked) {
                         R2Clicked = false;
                         return true;

--- a/XBOXUSB.cpp
+++ b/XBOXUSB.cpp
@@ -285,7 +285,8 @@ uint8_t XBOXUSB::getButtonPress(ButtonEnum b) {
                 return (uint8_t)(ButtonState >> 8);
         else if(b == R2)
                 return (uint8_t)ButtonState;
-        return (bool)(ButtonState & ((uint32_t)pgm_read_word(&XBOX_BUTTONS[(uint8_t)b]) << 16));
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        return (bool)(ButtonState & ((uint32_t)pgm_read_word(&XBOX_BUTTONS[index]) << 16));
 }
 
 bool XBOXUSB::getButtonClick(ButtonEnum b) {
@@ -302,7 +303,8 @@ bool XBOXUSB::getButtonClick(ButtonEnum b) {
                 }
                 return false;
         }
-        uint16_t button = pgm_read_word(&XBOX_BUTTONS[(uint8_t)b]);
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        uint16_t button = pgm_read_word(&XBOX_BUTTONS[index]);
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // clear "click" event
         return click;

--- a/XBOXUSB.cpp
+++ b/XBOXUSB.cpp
@@ -281,29 +281,29 @@ void XBOXUSB::printReport() { //Uncomment "#define PRINTREPORT" to print the rep
 }
 
 uint8_t XBOXUSB::getButtonPress(ButtonEnum b) {
-        if(b == L2) // These are analog buttons
-                return (uint8_t)(ButtonState >> 8);
-        else if(b == R2)
-                return (uint8_t)ButtonState;
         const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        if(index == legacyButtonValues(L2)) // These are analog buttons
+                return (uint8_t)(ButtonState >> 8);
+        else if(index == legacyButtonValues(R2))
+                return (uint8_t)ButtonState;
         return (bool)(ButtonState & ((uint32_t)pgm_read_word(&XBOX_BUTTONS[index]) << 16));
 }
 
 bool XBOXUSB::getButtonClick(ButtonEnum b) {
-        if(b == L2) {
+        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
+        if(index == legacyButtonValues(L2)) {
                 if(L2Clicked) {
                         L2Clicked = false;
                         return true;
                 }
                 return false;
-        } else if(b == R2) {
+        } else if(index == legacyButtonValues(R2)) {
                 if(R2Clicked) {
                         R2Clicked = false;
                         return true;
                 }
                 return false;
         }
-        const int8_t index = getXboxButtonIndex(b); if (index < 0) return 0;
         uint16_t button = pgm_read_word(&XBOX_BUTTONS[index]);
         bool click = (ButtonClickState & button);
         ButtonClickState &= ~button; // clear "click" event

--- a/controllerEnums.h
+++ b/controllerEnums.h
@@ -191,15 +191,15 @@ inline constexpr int8_t ButtonIndex(ButtonEnum key) {
         (key == DOWN || key == GREEN) ? 2 :
         (key == LEFT || key == ORANGE) ? 3 :
         (key == SELECT || key == SHARE || key == BACK || key == VIEW || key == BLUE || key == CREATE) ? 4 :
-        (key == PLUS || key == START || key == OPTIONS || key == MENU) ? 5 :
-        (key == TWO || key == L3) ? 6 :
-        (key == ONE || key == R3) ? 7 :
-        (key == MINUS || key == L2 || key == BLACK) ? 8 :
-        (key == HOME || key == R2 || key == WHITE) ? 9 :
-        (key == Z || key == L1) ? 10 :
-        (key == C || key == R1) ? 11 :
-        (key == B || key == TRIANGLE) ? 12 :
-        (key == A || key == CIRCLE) ? 13 :
+        (key == START || key == OPTIONS || key == MENU || key == PLUS) ? 5 :
+        (key == L3 || key == TWO) ? 6 :
+        (key == R3 || key == ONE) ? 7 :
+        (key == L2 || key == MINUS || key == BLACK) ? 8 :
+        (key == R2 || key == HOME || key == WHITE) ? 9 :
+        (key == L1 || key == Z) ? 10 :
+        (key == R1 || key == C) ? 11 :
+        (key == TRIANGLE || key == B) ? 12 :
+        (key == CIRCLE || key == A) ? 13 :
         (key == CROSS || key == X) ? 14 :
         (key == SQUARE || key == Y) ? 15 :
         (key == L || key == PS || key == XBOX) ? 16 :

--- a/controllerEnums.h
+++ b/controllerEnums.h
@@ -77,7 +77,7 @@ enum RumbleEnum {
 /** This enum is used to read all the different buttons on the different controllers */
 enum ButtonEnum {
         /**@{*/
-        /** These buttons are available on all the the controllers */
+        /** Directional Pad Buttons - available on most controllers */
         UP = 0,
         RIGHT = 1,
         DOWN = 2,
@@ -85,69 +85,30 @@ enum ButtonEnum {
         /**@}*/
 
         /**@{*/
-        /** Wii buttons */
-        PLUS,
-        TWO,
-        ONE,
-        MINUS,
-        HOME,
-        Z,
-        C,
-        B,
-        A,
-        /**@}*/
-
-        /**@{*/
-        /** These are only available on the Wii U Pro Controller */
-        L,
-        R,
-        ZL,
-        ZR,
-        /**@}*/
-
-        /**@{*/
-        /** PS3 controllers buttons */
-        SELECT,
-        START,
-        L3,
-        R3,
-
-        L2,
-        R2,
-        L1,
-        R1,
+        /** Playstation buttons */
         TRIANGLE,
         CIRCLE,
         CROSS,
         SQUARE,
 
-        PS,
+        SELECT,
+        START,
 
+        L3,
+        R3,
+
+        L1,
+        R1,
+        L2,
+        R2,
+
+        PS,
+        /**@}*/
+
+        /**@{*/
+        /** PS3 Move Controller */
         MOVE, // Covers 12 bits - we only need to read the top 8
         T, // Covers 12 bits - we only need to read the top 8
-        /**@}*/
-
-        /** PS4 controllers buttons - SHARE and OPTIONS are present instead of SELECT and START */
-        SHARE,
-        OPTIONS,
-        TOUCHPAD,
-        /**@}*/
-
-        /**@{*/
-        /** Xbox buttons */
-        BACK,
-        X,
-        Y,
-        XBOX,
-        SYNC,
-        BLACK, // Available on the original Xbox controller
-        WHITE, // Available on the original Xbox controller
-        /**@}*/
-
-        /**@{*/
-        /** Xbox One S buttons */
-        VIEW,
-        MENU,
         /**@}*/
 
         /**@{*/
@@ -160,9 +121,65 @@ enum ButtonEnum {
         /**@}*/
 
         /**@{*/
+        /** PS4 buttons - SHARE and OPTIONS are present instead of SELECT and START */
+        SHARE,
+        OPTIONS,
+        TOUCHPAD,
+        /**@}*/
+
+        /**@{*/
         /** PS5 buttons */
         CREATE,
         MICROPHONE,
+        /**@}*/
+
+        /**@{*/
+        /** Xbox buttons */
+        A,
+        B,
+        X,
+        Y,
+
+        BACK,
+        // START,  // listed under Playstation buttons
+
+        // L1,  // listed under Playstation buttons
+        // R1,  // listed under Playstation buttons
+        // L2,  // listed under Playstation buttons
+        // R2,  // listed under Playstation buttons
+
+        XBOX,
+        SYNC,
+
+        BLACK, // Available on the original Xbox controller
+        WHITE, // Available on the original Xbox controller
+        /**@}*/
+
+        /**@{*/
+        /** Xbox One S buttons */
+        VIEW,
+        MENU,
+        /**@}*/
+
+        /**@{*/
+        /** Wii buttons */
+        PLUS,
+        TWO,
+        ONE,
+        MINUS,
+        HOME,
+        Z,
+        C,
+        // B,  // listed under Xbox buttons
+        // A,  // listed under Xbox buttons
+        /**@}*/
+
+        /**@{*/
+        /** Wii U Pro Controller */
+        L,
+        R,
+        ZL,
+        ZR,
         /**@}*/
 };
 

--- a/controllerEnums.h
+++ b/controllerEnums.h
@@ -183,83 +183,30 @@ enum ButtonEnum {
         /**@}*/
 };
 
-inline int8_t legacyButtonValues(ButtonEnum key) {
-    switch (key) {
-    case UP:
-    case RED:
-        return 0;
-    case RIGHT:
-    case YELLOW:
-        return 1;
-    case DOWN:
-    case GREEN:
-        return 2;
-    case LEFT:
-    case ORANGE:
-        return 3;
-    case SELECT:
-    case SHARE:
-    case BACK:
-    case VIEW:
-    case BLUE:
-    case CREATE:
-        return 4;
-    case PLUS:
-    case START:
-    case OPTIONS:
-    case MENU:
-        return 5;
-    case TWO:
-    case L3:
-        return 6;
-    case ONE:
-    case R3:
-        return 7;
-    case MINUS:
-    case L2:
-    case BLACK:
-        return 8;
-    case HOME:
-    case R2:
-    case WHITE:
-        return 9;
-    case Z:
-    case L1:
-        return 10;
-    case C:
-    case R1:
-        return 11;
-    case B:
-    case TRIANGLE:
-        return 12;
-    case A:
-    case CIRCLE:
-        return 13;
-    case CROSS:
-    case X:
-        return 14;
-    case SQUARE:
-    case Y:
-        return 15;
-    case L:
-    case PS:
-    case XBOX:
-        return 16;
-    case R:
-    case MOVE:
-    case TOUCHPAD:
-    case SYNC:
-        return 17;
-    case ZL:
-    case T:
-    case MICROPHONE:
-        return 18;
-    case ZR:
-        return 19;
-    default:
-        return -1;
-    }
-    return -1;
+inline constexpr int8_t legacyButtonValues(ButtonEnum key) {
+    // using a chained ternary in place of a switch for constexpr on older compilers
+    return
+        (key == UP || key == RED) ? 0 :
+        (key == RIGHT || key == YELLOW) ? 1 :
+        (key == DOWN || key == GREEN) ? 2 :
+        (key == LEFT || key == ORANGE) ? 3 :
+        (key == SELECT || key == SHARE || key == BACK || key == VIEW || key == BLUE || key == CREATE) ? 4 :
+        (key == PLUS || key == START || key == OPTIONS || key == MENU) ? 5 :
+        (key == TWO || key == L3) ? 6 :
+        (key == ONE || key == R3) ? 7 :
+        (key == MINUS || key == L2 || key == BLACK) ? 8 :
+        (key == HOME || key == R2 || key == WHITE) ? 9 :
+        (key == Z || key == L1) ? 10 :
+        (key == C || key == R1) ? 11 :
+        (key == B || key == TRIANGLE) ? 12 :
+        (key == A || key == CIRCLE) ? 13 :
+        (key == CROSS || key == X) ? 14 :
+        (key == SQUARE || key == Y) ? 15 :
+        (key == L || key == PS || key == XBOX) ? 16 :
+        (key == R || key == MOVE || key == TOUCHPAD || key == SYNC) ? 17 :
+        (key == ZL || key == T || key == MICROPHONE) ? 18 :
+        (key == ZR) ? 19 :
+        -1;  // not a match
 }
 
 /** Joysticks on the PS3 and Xbox controllers. */

--- a/controllerEnums.h
+++ b/controllerEnums.h
@@ -86,85 +86,168 @@ enum ButtonEnum {
 
         /**@{*/
         /** Wii buttons */
-        PLUS = 5,
-        TWO = 6,
-        ONE = 7,
-        MINUS = 8,
-        HOME = 9,
-        Z = 10,
-        C = 11,
-        B = 12,
-        A = 13,
+        PLUS,
+        TWO,
+        ONE,
+        MINUS,
+        HOME,
+        Z,
+        C,
+        B,
+        A,
         /**@}*/
 
         /**@{*/
         /** These are only available on the Wii U Pro Controller */
-        L = 16,
-        R = 17,
-        ZL = 18,
-        ZR = 19,
+        L,
+        R,
+        ZL,
+        ZR,
         /**@}*/
 
         /**@{*/
         /** PS3 controllers buttons */
-        SELECT = 4,
-        START = 5,
-        L3 = 6,
-        R3 = 7,
+        SELECT,
+        START,
+        L3,
+        R3,
 
-        L2 = 8,
-        R2 = 9,
-        L1 = 10,
-        R1 = 11,
-        TRIANGLE = 12,
-        CIRCLE = 13,
-        CROSS = 14,
-        SQUARE = 15,
+        L2,
+        R2,
+        L1,
+        R1,
+        TRIANGLE,
+        CIRCLE,
+        CROSS,
+        SQUARE,
 
-        PS = 16,
+        PS,
 
-        MOVE = 17, // Covers 12 bits - we only need to read the top 8
-        T = 18, // Covers 12 bits - we only need to read the top 8
+        MOVE, // Covers 12 bits - we only need to read the top 8
+        T, // Covers 12 bits - we only need to read the top 8
         /**@}*/
 
         /** PS4 controllers buttons - SHARE and OPTIONS are present instead of SELECT and START */
-        SHARE = 4,
-        OPTIONS = 5,
-        TOUCHPAD = 17,
+        SHARE,
+        OPTIONS,
+        TOUCHPAD,
         /**@}*/
 
         /**@{*/
         /** Xbox buttons */
-        BACK = 4,
-        X = 14,
-        Y = 15,
-        XBOX = 16,
-        SYNC = 17,
-        BLACK = 8, // Available on the original Xbox controller
-        WHITE = 9, // Available on the original Xbox controller
+        BACK,
+        X,
+        Y,
+        XBOX,
+        SYNC,
+        BLACK, // Available on the original Xbox controller
+        WHITE, // Available on the original Xbox controller
         /**@}*/
 
         /**@{*/
         /** Xbox One S buttons */
-        VIEW = 4,
-        MENU = 5,
+        VIEW,
+        MENU,
         /**@}*/
 
         /**@{*/
         /** PS Buzz controllers */
-        RED = 0,
-        YELLOW = 1,
-        GREEN = 2,
-        ORANGE = 3,
-        BLUE = 4,
+        RED,
+        YELLOW,
+        GREEN,
+        ORANGE,
+        BLUE,
         /**@}*/
 
         /**@{*/
         /** PS5 buttons */
-        CREATE = 4,
-        MICROPHONE = 18,
+        CREATE,
+        MICROPHONE,
         /**@}*/
 };
+
+inline uint8_t legacyButtonValues(ButtonEnum key) {
+    uint8_t out;
+
+    switch (key) {
+    case UP:
+    case RED:
+        out = 0; break;
+    case RIGHT:
+    case YELLOW:
+        out = 1; break;
+    case DOWN:
+    case GREEN:
+        out = 2; break;
+    case LEFT:
+    case ORANGE:
+        out = 3; break;
+    case SELECT:
+    case SHARE:
+    case BACK:
+    case VIEW:
+    case BLUE:
+    case CREATE:
+        out = 4; break;
+    case PLUS:
+    case START:
+    case OPTIONS:
+    case MENU:
+        out = 5; break;
+    case TWO:
+    case L3:
+        out = 6; break;
+    case ONE:
+    case R3:
+        out = 7; break;
+    case MINUS:
+    case L2:
+    case BLACK:
+        out = 8; break;
+    case HOME:
+    case R2:
+    case WHITE:
+        out = 9; break;
+    case Z:
+    case L1:
+        out = 10; break;
+    case C:
+    case R1:
+        out = 11; break;
+    case B:
+    case TRIANGLE:
+        out = 12; break;
+    case A:
+    case CIRCLE:
+        out = 13; break;
+    case CROSS:
+    case X:
+        out = 14; break;
+    case SQUARE:
+    case Y:
+        out = 15; break;
+    case L:
+    case PS:
+    case XBOX:
+        out = 16; break;
+    case R:
+    case MOVE:
+    case TOUCHPAD:
+        out = 17; break;
+    case SYNC:
+        out = 17; break;
+    case ZL:
+    case T:
+    case MICROPHONE:
+        out = 18; break;
+    case ZR:
+        out = 19; break;
+    default:
+        out = 0; break;
+    }
+
+    return out;
+}
 
 /** Joysticks on the PS3 and Xbox controllers. */
 enum AnalogHatEnum {

--- a/controllerEnums.h
+++ b/controllerEnums.h
@@ -183,7 +183,7 @@ enum ButtonEnum {
         /**@}*/
 };
 
-inline constexpr int8_t legacyButtonValues(ButtonEnum key) {
+inline constexpr int8_t ButtonIndex(ButtonEnum key) {
     // using a chained ternary in place of a switch for constexpr on older compilers
     return
         (key == UP || key == RED) ? 0 :

--- a/controllerEnums.h
+++ b/controllerEnums.h
@@ -183,87 +183,83 @@ enum ButtonEnum {
         /**@}*/
 };
 
-inline uint8_t legacyButtonValues(ButtonEnum key) {
-    uint8_t out;
-
+inline int8_t legacyButtonValues(ButtonEnum key) {
     switch (key) {
     case UP:
     case RED:
-        out = 0; break;
+        return 0;
     case RIGHT:
     case YELLOW:
-        out = 1; break;
+        return 1;
     case DOWN:
     case GREEN:
-        out = 2; break;
+        return 2;
     case LEFT:
     case ORANGE:
-        out = 3; break;
+        return 3;
     case SELECT:
     case SHARE:
     case BACK:
     case VIEW:
     case BLUE:
     case CREATE:
-        out = 4; break;
+        return 4;
     case PLUS:
     case START:
     case OPTIONS:
     case MENU:
-        out = 5; break;
+        return 5;
     case TWO:
     case L3:
-        out = 6; break;
+        return 6;
     case ONE:
     case R3:
-        out = 7; break;
+        return 7;
     case MINUS:
     case L2:
     case BLACK:
-        out = 8; break;
+        return 8;
     case HOME:
     case R2:
     case WHITE:
-        out = 9; break;
+        return 9;
     case Z:
     case L1:
-        out = 10; break;
+        return 10;
     case C:
     case R1:
-        out = 11; break;
+        return 11;
     case B:
     case TRIANGLE:
-        out = 12; break;
+        return 12;
     case A:
     case CIRCLE:
-        out = 13; break;
+        return 13;
     case CROSS:
     case X:
-        out = 14; break;
+        return 14;
     case SQUARE:
     case Y:
-        out = 15; break;
+        return 15;
     case L:
     case PS:
     case XBOX:
-        out = 16; break;
+        return 16;
     case R:
     case MOVE:
     case TOUCHPAD:
-        out = 17; break;
     case SYNC:
-        out = 17; break;
+        return 17;
     case ZL:
     case T:
     case MICROPHONE:
-        out = 18; break;
+        return 18;
     case ZR:
-        out = 19; break;
+        return 19;
     default:
-        out = 0; break;
+        return -1;
     }
-
-    return out;
+    return -1;
 }
 
 /** Joysticks on the PS3 and Xbox controllers. */

--- a/xboxEnums.h
+++ b/xboxEnums.h
@@ -62,4 +62,10 @@ const uint16_t XBOX_BUTTONS[] PROGMEM = {
         0x0008, // SYNC
 };
 
+inline int8_t getXboxButtonIndex(ButtonEnum b) {
+        const uint8_t index = legacyButtonValues(b);
+        if (index >= sizeof(XBOX_BUTTONS) / sizeof(XBOX_BUTTONS[0])) return -1;
+        return index;
+}
+
 #endif

--- a/xboxEnums.h
+++ b/xboxEnums.h
@@ -62,10 +62,8 @@ const uint16_t XBOX_BUTTONS[] PROGMEM = {
         0x0008, // SYNC
 };
 
-inline int8_t getXboxButtonIndex(ButtonEnum b) {
-        const int8_t index = legacyButtonValues(b);
-        if ((uint8_t) index >= (sizeof(XBOX_BUTTONS) / sizeof(XBOX_BUTTONS[0]))) return -1;
-        return index;
+inline constexpr int8_t getXboxButtonIndex(ButtonEnum b) {
+        return (uint8_t) legacyButtonValues(b) >= (sizeof(XBOX_BUTTONS) / sizeof(XBOX_BUTTONS[0])) ? -1 : legacyButtonValues(b);
 }
 
 #endif

--- a/xboxEnums.h
+++ b/xboxEnums.h
@@ -62,8 +62,10 @@ const uint16_t XBOX_BUTTONS[] PROGMEM = {
         0x0008, // SYNC
 };
 
-inline constexpr int8_t getXboxButtonIndex(ButtonEnum b) {
-        return (uint8_t) legacyButtonValues(b) >= (sizeof(XBOX_BUTTONS) / sizeof(XBOX_BUTTONS[0])) ? -1 : legacyButtonValues(b);
+inline int8_t getXboxButtonIndex(ButtonEnum b) {
+        const int8_t index = legacyButtonValues(b);
+        if ((uint8_t) index >= (sizeof(XBOX_BUTTONS) / sizeof(XBOX_BUTTONS[0]))) return -1;
+        return index;
 }
 
 #endif

--- a/xboxEnums.h
+++ b/xboxEnums.h
@@ -63,8 +63,8 @@ const uint16_t XBOX_BUTTONS[] PROGMEM = {
 };
 
 inline int8_t getXboxButtonIndex(ButtonEnum b) {
-        const uint8_t index = legacyButtonValues(b);
-        if (index >= sizeof(XBOX_BUTTONS) / sizeof(XBOX_BUTTONS[0])) return -1;
+        const int8_t index = legacyButtonValues(b);
+        if ((uint8_t) index >= (sizeof(XBOX_BUTTONS) / sizeof(XBOX_BUTTONS[0]))) return -1;
         return index;
 }
 

--- a/xboxEnums.h
+++ b/xboxEnums.h
@@ -62,8 +62,8 @@ const uint16_t XBOX_BUTTONS[] PROGMEM = {
         0x0008, // SYNC
 };
 
-inline int8_t getXboxButtonIndex(ButtonEnum b) {
-        const int8_t index = legacyButtonValues(b);
+inline int8_t getButtonIndexXbox(ButtonEnum b) {
+        const int8_t index = ButtonIndex(b);
         if ((uint8_t) index >= (sizeof(XBOX_BUTTONS) / sizeof(XBOX_BUTTONS[0]))) return -1;
         return index;
 }


### PR DESCRIPTION
Removes the number values associated with each `ButtonEnum` key so that all button identifiers are unique. This fixes issue #611 and potential future issues with the same problem.

Everywhere that referenced one of the enum values directly has been replaced with the `constexpr` function `ButtonIndex` which returns the previously associated value. Each controller now has its own `getButtonIndex` function which takes a `ButtonEnum` value and returns the relevant index value for that key, or `-1` if the key (or previously equivalent aliases) are not present on that controller.

This adds some overhead due to the function calls and also slightly modifies the public interface, because the numbered equivalents for the enums can no longer be used. All previously associated key aliases such as `SELECT` and `BACK` should still be maintained and work as they did before. This also adds bounds checking to all functions taking `ButtonEnum` as a parameter, so control indices out of range for a given controller now return '0' instead of attempting to read out of bounds memory.

I've tested this with the following controllers:
* Xbox Original (`XBOXOLD`)
* Xbox 360 Wired (`XBOXUSB`)
* Xbox 360 Wireless (`XBOXRECV`)
* Xbox Core Controller (`XBOXONE`)
* PS3 Wired (`PS3USB`)
* PS4 Wired (`PS4USB`)

Let me know if you see anything out of sorts.
