### PR TITLE
hidboot: Fix buffer size and check maxPacketSize #646

### DIFF
--- a/hidboot.h
+++ b/hidboot.h
@@ -582,13 +582,17 @@ uint8_t HIDBoot<BOOT_PROTOCOL>::Poll() {
 
                 // To-do: optimize manually, using the for loop only if needed.
                 for(int i = 0; i < epMUL(BOOT_PROTOCOL); i++) {
-                        const uint16_t const_buff_len = 16;
-                        uint8_t buf[const_buff_len];
+                        const uint16_t const_buff_len = 64;
 
                         USBTRACE3("(hidboot.h) i=", i, 0x81);
                         USBTRACE3("(hidboot.h) epInfo[epInterruptInIndex + i].epAddr=", epInfo[epInterruptInIndex + i].epAddr, 0x81);
                         USBTRACE3("(hidboot.h) epInfo[epInterruptInIndex + i].maxPktSize=", epInfo[epInterruptInIndex + i].maxPktSize, 0x81);
                         uint16_t read = (uint16_t)epInfo[epInterruptInIndex + i].maxPktSize;
+
+                        if (read > const_buff_len)
+                            read = const_buff_len;
+
+                        uint8_t buf[read];
 
                         rcode = pUsb->inTransfer(bAddress, epInfo[epInterruptInIndex + i].epAddr, &read, buf);
                         // SOME buggy dongles report extra keys (like sleep) using a 2 byte packet on the wrong endpoint.


### PR DESCRIPTION
This fixes buffer handling in `Poll()` of hidboot.h. #646

`Poll()` can cause buffer overrun in `inTransfer()` becase it uses `maxPktSize` as buffer size without checking.
https://github.com/felis/USB_Host_Shield_2.0/blob/08121e1701908006cd646ad51b8c93cf7fe4ce7a/hidboot.h#L585-L593

