### PR TITLE
Add Xbox Trigger Enums

### DIFF
--- a/XBOXOLD.cpp
+++ b/XBOXOLD.cpp
@@ -118,7 +118,7 @@ uint8_t XBOXOLD::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         VID = udd->idVendor;
         PID = udd->idProduct;
 
-        if((VID != XBOX_VID && VID != MADCATZ_VID && VID != JOYTECH_VID) || (PID != XBOX_OLD_PID1 && PID != XBOX_OLD_PID2 && PID != XBOX_OLD_PID3 && PID != XBOX_OLD_PID4)) // Check if VID and PID match
+        if(!VIDPIDOK(VID, PID)) // Check if VID and PID match
                 goto FailUnknownDevice;
 
         // Allocate new address according to device class

--- a/XBOXOLD.cpp
+++ b/XBOXOLD.cpp
@@ -293,6 +293,19 @@ void XBOXOLD::printReport(uint16_t length __attribute__((unused))) { //Uncomment
 }
 
 int8_t XBOXOLD::getAnalogIndex(ButtonEnum b) {
+        // For legacy reasons these mapping indices not match up,
+        // as the original code uses L1/R1 for the triggers and
+        // L2/R2 for the white/black buttons. To fix these new enums
+        // we have to transpose the keys before passing them through
+        // the button index function
+        switch (b) {
+        case(LT): b = L1; break;  // normally L2
+        case(RT): b = R1; break;  // normally R2
+        case(LB): b = WHITE; break;  // normally L1
+        case(RB): b = BLACK; break;  // normally R1
+        default: break;
+        }
+
         // A, B, X, Y, BLACK, WHITE, L1, and R1 are analog buttons
         const int8_t index = ButtonIndex(b);
 

--- a/XBOXOLD.h
+++ b/XBOXOLD.h
@@ -34,11 +34,13 @@
 #define XBOX_VID                                0x045E // Microsoft Corporation
 #define MADCATZ_VID                             0x1BAD // For unofficial Mad Catz controllers
 #define JOYTECH_VID                             0x162E // For unofficial Joytech controllers
+#define LOGITECH_VID                            0x046D // For official Logitech controllers
 
 #define XBOX_OLD_PID1                           0x0202 // Original Microsoft Xbox controller (US)
 #define XBOX_OLD_PID2                           0x0285 // Original Microsoft Xbox controller (Japan)
 #define XBOX_OLD_PID3                           0x0287 // Microsoft Microsoft Xbox Controller S
 #define XBOX_OLD_PID4                           0x0289 // Smaller Microsoft Xbox controller (US)
+#define XBOX_OLD_PID5                           0xCA84 // Logitech Cordless Precision controller
 
 #define XBOX_MAX_ENDPOINTS   3
 
@@ -94,7 +96,7 @@ public:
          * @return     Returns true if the device's VID and PID matches this driver.
          */
         virtual bool VIDPIDOK(uint16_t vid, uint16_t pid) {
-                return ((vid == XBOX_VID || vid == MADCATZ_VID || vid == JOYTECH_VID) && (pid == XBOX_OLD_PID1 || pid == XBOX_OLD_PID2 || pid == XBOX_OLD_PID3 || pid == XBOX_OLD_PID4));
+                return ((vid == XBOX_VID || vid == MADCATZ_VID || vid == JOYTECH_VID || vid == LOGITECH_VID) && (pid == XBOX_OLD_PID1 || pid == XBOX_OLD_PID2 || pid == XBOX_OLD_PID3 || pid == XBOX_OLD_PID4 || pid == XBOX_OLD_PID5));
         };
         /**@}*/
 

--- a/controllerEnums.h
+++ b/controllerEnums.h
@@ -143,10 +143,10 @@ enum ButtonEnum {
         BACK,
         // START,  // listed under Playstation buttons
 
-        // L1,  // listed under Playstation buttons
-        // R1,  // listed under Playstation buttons
-        // L2,  // listed under Playstation buttons
-        // R2,  // listed under Playstation buttons
+        LB,
+        RB,
+        LT,
+        RT,
 
         XBOX,
         SYNC,
@@ -199,10 +199,10 @@ inline constexpr int8_t ButtonIndex(ButtonEnum key) {
         (key == START || key == OPTIONS || key == MENU || key == PLUS) ? 5 :
         (key == L3 || key == TWO) ? 6 :
         (key == R3 || key == ONE) ? 7 :
-        (key == L2 || key == MINUS || key == BLACK) ? 8 :
-        (key == R2 || key == HOME || key == WHITE) ? 9 :
-        (key == L1 || key == Z) ? 10 :
-        (key == R1 || key == C) ? 11 :
+        (key == L2 || key == LT || key == MINUS || key == BLACK) ? 8 :
+        (key == R2 || key == RT || key == HOME || key == WHITE) ? 9 :
+        (key == L1 || key == LB || key == Z) ? 10 :
+        (key == R1 || key == RB || key == C) ? 11 :
         (key == TRIANGLE || key == B) ? 12 :
         (key == CIRCLE || key == A) ? 13 :
         (key == CROSS || key == X) ? 14 :

--- a/examples/Xbox/XBOXOLD/XBOXOLD.ino
+++ b/examples/Xbox/XBOXOLD/XBOXOLD.ino
@@ -97,13 +97,13 @@ void loop() {
       Serial.print(F("Y: "));
       Serial.println(Xbox.getButtonPress(Y));
     }
-    if (Xbox.getButtonPress(L1)) {
-      Serial.print(F("L1: "));
-      Serial.println(Xbox.getButtonPress(L1));
+    if (Xbox.getButtonPress(LT)) {
+      Serial.print(F("LT: "));
+      Serial.println(Xbox.getButtonPress(LT));
     }
-    if (Xbox.getButtonPress(R1)) {
-      Serial.print(F("R1: "));
-      Serial.println(Xbox.getButtonPress(R1));
+    if (Xbox.getButtonPress(RT)) {
+      Serial.print(F("RT: "));
+      Serial.println(Xbox.getButtonPress(RT));
     }
   }
   delay(1);

--- a/examples/Xbox/XBOXONE/XBOXONE.ino
+++ b/examples/Xbox/XBOXONE/XBOXONE.ino
@@ -64,12 +64,12 @@ void loop() {
     }
 
     // Set rumble effect
-    static uint16_t oldL2Value, oldR2Value;
-    if (Xbox.getButtonPress(L2) != oldL2Value || Xbox.getButtonPress(R2) != oldR2Value) {
-      oldL2Value = Xbox.getButtonPress(L2);
-      oldR2Value = Xbox.getButtonPress(R2);
-      uint8_t leftRumble = map(oldL2Value, 0, 1023, 0, 255); // Map the trigger values into a byte
-      uint8_t rightRumble = map(oldR2Value, 0, 1023, 0, 255);
+    static uint16_t oldLTValue, oldRTValue;
+    if (Xbox.getButtonPress(LT) != oldLTValue || Xbox.getButtonPress(RT) != oldRTValue) {
+      oldLTValue = Xbox.getButtonPress(LT);
+      oldRTValue = Xbox.getButtonPress(RT);
+      uint8_t leftRumble = map(oldLTValue, 0, 1023, 0, 255); // Map the trigger values into a byte
+      uint8_t rightRumble = map(oldRTValue, 0, 1023, 0, 255);
       if (leftRumble > 0 || rightRumble > 0)
         Xbox.setRumbleOn(leftRumble, rightRumble, leftRumble, rightRumble);
       else

--- a/examples/Xbox/XBOXONE/XBOXONE.ino
+++ b/examples/Xbox/XBOXONE/XBOXONE.ino
@@ -49,15 +49,15 @@ void loop() {
       Serial.println();
     }
 
-    if (Xbox.getButtonPress(L2) > 0 || Xbox.getButtonPress(R2) > 0) {
-      if (Xbox.getButtonPress(L2) > 0) {
-        Serial.print(F("L2: "));
-        Serial.print(Xbox.getButtonPress(L2));
+    if (Xbox.getButtonPress(LT) > 0 || Xbox.getButtonPress(RT) > 0) {
+      if (Xbox.getButtonPress(LT) > 0) {
+        Serial.print(F("LT: "));
+        Serial.print(Xbox.getButtonPress(LT));
         Serial.print("\t");
       }
-      if (Xbox.getButtonPress(R2) > 0) {
-        Serial.print(F("R2: "));
-        Serial.print(Xbox.getButtonPress(R2));
+      if (Xbox.getButtonPress(RT) > 0) {
+        Serial.print(F("RT: "));
+        Serial.print(Xbox.getButtonPress(RT));
         Serial.print("\t");
       }
       Serial.println();
@@ -94,14 +94,14 @@ void loop() {
     if (Xbox.getButtonClick(SYNC))
       Serial.println(F("Sync"));
 
-    if (Xbox.getButtonClick(L1))
-      Serial.println(F("L1"));
-    if (Xbox.getButtonClick(R1))
-      Serial.println(F("R1"));
-    if (Xbox.getButtonClick(L2))
-      Serial.println(F("L2"));
-    if (Xbox.getButtonClick(R2))
-      Serial.println(F("R2"));
+    if (Xbox.getButtonClick(LB))
+      Serial.println(F("LB"));
+    if (Xbox.getButtonClick(RB))
+      Serial.println(F("RB"));
+    if (Xbox.getButtonClick(LT))
+      Serial.println(F("LT"));
+    if (Xbox.getButtonClick(RT))
+      Serial.println(F("RT"));
     if (Xbox.getButtonClick(L3))
       Serial.println(F("L3"));
     if (Xbox.getButtonClick(R3))

--- a/examples/Xbox/XBOXONESBT/XBOXONESBT.ino
+++ b/examples/Xbox/XBOXONESBT/XBOXONESBT.ino
@@ -63,27 +63,27 @@ void loop() {
       Serial.println();
     }
 
-    if (Xbox.getButtonPress(L2) > 0 || Xbox.getButtonPress(R2) > 0) {
-      if (Xbox.getButtonPress(L2) > 0) {
-        Serial.print(F("L2: "));
-        Serial.print(Xbox.getButtonPress(L2));
+    if (Xbox.getButtonPress(LT) > 0 || Xbox.getButtonPress(RT) > 0) {
+      if (Xbox.getButtonPress(LT) > 0) {
+        Serial.print(F("LT: "));
+        Serial.print(Xbox.getButtonPress(LT));
         Serial.print("\t");
       }
-      if (Xbox.getButtonPress(R2) > 0) {
-        Serial.print(F("R2: "));
-        Serial.print(Xbox.getButtonPress(R2));
+      if (Xbox.getButtonPress(RT) > 0) {
+        Serial.print(F("RT: "));
+        Serial.print(Xbox.getButtonPress(RT));
         Serial.print("\t");
       }
       Serial.println();
     }
 
     // Set rumble effect
-    static uint16_t oldL2Value, oldR2Value;
-    if (Xbox.getButtonPress(L2) != oldL2Value || Xbox.getButtonPress(R2) != oldR2Value) {
-      oldL2Value = Xbox.getButtonPress(L2);
-      oldR2Value = Xbox.getButtonPress(R2);
-      uint8_t leftRumble = map(oldL2Value, 0, 1023, 0, 255); // Map the trigger values into a byte
-      uint8_t rightRumble = map(oldR2Value, 0, 1023, 0, 255);
+    static uint16_t oldLTValue, oldRTValue;
+    if (Xbox.getButtonPress(LT) != oldLTValue || Xbox.getButtonPress(RT) != oldRTValue) {
+      oldLTValue = Xbox.getButtonPress(LT);
+      oldRTValue = Xbox.getButtonPress(RT);
+      uint8_t leftRumble = map(oldLTValue, 0, 1023, 0, 255); // Map the trigger values into a byte
+      uint8_t rightRumble = map(oldRTValue, 0, 1023, 0, 255);
       if (leftRumble > 0 || rightRumble > 0)
         Xbox.setRumbleOn(leftRumble, rightRumble, leftRumble, rightRumble);
       else
@@ -108,14 +108,14 @@ void loop() {
       Xbox.disconnect();
     }
 
-    if (Xbox.getButtonClick(L1))
-      Serial.println(F("L1"));
-    if (Xbox.getButtonClick(R1))
-      Serial.println(F("R1"));
-    if (Xbox.getButtonClick(L2))
-      Serial.println(F("L2"));
-    if (Xbox.getButtonClick(R2))
-      Serial.println(F("R2"));
+    if (Xbox.getButtonClick(LB))
+      Serial.println(F("LB"));
+    if (Xbox.getButtonClick(RB))
+      Serial.println(F("RB"));
+    if (Xbox.getButtonClick(LT))
+      Serial.println(F("LT"));
+    if (Xbox.getButtonClick(RT))
+      Serial.println(F("RT"));
     if (Xbox.getButtonClick(L3))
       Serial.println(F("L3"));
     if (Xbox.getButtonClick(R3))

--- a/examples/Xbox/XBOXRECV/XBOXRECV.ino
+++ b/examples/Xbox/XBOXRECV/XBOXRECV.ino
@@ -32,12 +32,12 @@ void loop() {
   if (Xbox.XboxReceiverConnected) {
     for (uint8_t i = 0; i < 4; i++) {
       if (Xbox.Xbox360Connected[i]) {
-        if (Xbox.getButtonPress(L2, i) || Xbox.getButtonPress(R2, i)) {
-          Serial.print("L2: ");
-          Serial.print(Xbox.getButtonPress(L2, i));
-          Serial.print("\tR2: ");
-          Serial.println(Xbox.getButtonPress(R2, i));
-          Xbox.setRumbleOn(Xbox.getButtonPress(L2, i), Xbox.getButtonPress(R2, i), i);
+        if (Xbox.getButtonPress(LT, i) || Xbox.getButtonPress(RT, i)) {
+          Serial.print("LT: ");
+          Serial.print(Xbox.getButtonPress(LT, i));
+          Serial.print("\tRT: ");
+          Serial.println(Xbox.getButtonPress(RT, i));
+          Xbox.setRumbleOn(Xbox.getButtonPress(LT, i), Xbox.getButtonPress(RT, i), i);
         }
 
         if (Xbox.getAnalogHat(LeftHatX, i) > 7500 || Xbox.getAnalogHat(LeftHatX, i) < -7500 || Xbox.getAnalogHat(LeftHatY, i) > 7500 || Xbox.getAnalogHat(LeftHatY, i) < -7500 || Xbox.getAnalogHat(RightHatX, i) > 7500 || Xbox.getAnalogHat(RightHatX, i) < -7500 || Xbox.getAnalogHat(RightHatY, i) > 7500 || Xbox.getAnalogHat(RightHatY, i) < -7500) {
@@ -93,10 +93,10 @@ void loop() {
         if (Xbox.getButtonClick(R3, i))
           Serial.println(F("R3"));
 
-        if (Xbox.getButtonClick(L1, i))
-          Serial.println(F("L1"));
-        if (Xbox.getButtonClick(R1, i))
-          Serial.println(F("R1"));
+        if (Xbox.getButtonClick(LB, i))
+          Serial.println(F("LB"));
+        if (Xbox.getButtonClick(RB, i))
+          Serial.println(F("RB"));
         if (Xbox.getButtonClick(XBOX, i)) {
           Xbox.setLedMode(ROTATING, i);
           Serial.print(F("Xbox (Battery: "));

--- a/examples/Xbox/XBOXUSB/XBOXUSB.ino
+++ b/examples/Xbox/XBOXUSB/XBOXUSB.ino
@@ -29,12 +29,12 @@ void setup() {
 void loop() {
   Usb.Task();
   if (Xbox.Xbox360Connected) {
-    if (Xbox.getButtonPress(L2) || Xbox.getButtonPress(R2)) {
-      Serial.print("L2: ");
-      Serial.print(Xbox.getButtonPress(L2));
-      Serial.print("\tR2: ");
-      Serial.println(Xbox.getButtonPress(R2));
-      Xbox.setRumbleOn(Xbox.getButtonPress(L2), Xbox.getButtonPress(R2));
+    if (Xbox.getButtonPress(LT) || Xbox.getButtonPress(RT)) {
+      Serial.print("LT: ");
+      Serial.print(Xbox.getButtonPress(LT));
+      Serial.print("\tRT: ");
+      Serial.println(Xbox.getButtonPress(RT));
+      Xbox.setRumbleOn(Xbox.getButtonPress(LT), Xbox.getButtonPress(RT));
     } else
       Xbox.setRumbleOn(0, 0);
 
@@ -91,10 +91,10 @@ void loop() {
     if (Xbox.getButtonClick(R3))
       Serial.println(F("R3"));
 
-    if (Xbox.getButtonClick(L1))
-      Serial.println(F("L1"));
-    if (Xbox.getButtonClick(R1))
-      Serial.println(F("R1"));
+    if (Xbox.getButtonClick(LB))
+      Serial.println(F("LB"));
+    if (Xbox.getButtonClick(RB))
+      Serial.println(F("RB"));
     if (Xbox.getButtonClick(XBOX)) {
       Xbox.setLedMode(ROTATING);
       Serial.println(F("Xbox"));

--- a/keywords.txt
+++ b/keywords.txt
@@ -253,6 +253,12 @@ B	LITERAL1
 X	LITERAL1
 Y	LITERAL1
 
+LB	LITERAL1
+RB	LITERAL1
+
+LT	LITERAL1
+RT	LITERAL1
+
 ####################################################
 # Syntax Coloring Map For RFCOMM/SPP Library
 ####################################################


### PR DESCRIPTION
This adds `LB/RB` and `LT/RT` enum values for the Xbox controllers, in place of the original `L1/R1` and `L2/R2` keys. These are how Microsoft refers to the controls, and what is molded into the plastic on the Xbox 360 controllers. I've also updated the Xbox examples to swap out the keys and related strings.

While I was modifying the Original Xbox code, I also changed a duplicate reference to the VID/PID check and added support for the "Logitech Cordless Precision" controller.

This change uses the same button index value as before, so it should be backwards compatible with previous versions. The old key values can also still be used without issue.
