### PR TITLE
Improve plugin detection in busprobe()

### DIFF
--- a/usbhost.h
+++ b/usbhost.h
@@ -503,9 +503,28 @@ int8_t MAX3421e< SPI_SS, INTR >::Init(int mseconds) {
 /* probe bus to determine device presence and speed and switch host to this speed */
 template< typename SPI_SS, typename INTR >
 void MAX3421e< SPI_SS, INTR >::busprobe() {
+        static uint8_t prev_bus = -1;
         uint8_t bus_sample;
+
+        if (regRd(rHIRQ) & bmCONDETIRQ) {
+            // device plug/unplug is detected
+            // clear CONDETIRQ
+            regWr(rHIRQ, bmCONDETIRQ);
+        } else {
+            // check current bus state when no device(SE0),
+            // otherwise transient state will be read due to bus activity.
+            if (vbusState != SE0) return;
+
+            // read current bus state
+            regWr(rHCTL, bmSAMPLEBUS);
+        }
+
         bus_sample = regRd(rHRSL); //Get J,K status
         bus_sample &= (bmJSTATUS | bmKSTATUS); //zero the rest of the byte
+
+        if (prev_bus == bus_sample) { return; }
+        prev_bus = bus_sample;
+
         switch(bus_sample) { //start full-speed or low-speed host
                 case( bmJSTATUS):
                         if((regRd(rMODE) & bmLOWSPEED) == 0) {
@@ -538,6 +557,7 @@ void MAX3421e< SPI_SS, INTR >::busprobe() {
 /* MAX3421 state change task and interrupt handler */
 template< typename SPI_SS, typename INTR >
 uint8_t MAX3421e< SPI_SS, INTR >::Task(void) {
+        /*
         uint8_t rcode = 0;
         uint8_t pinvalue;
         //USB_HOST_SERIAL.print("Vbus state: ");
@@ -553,6 +573,9 @@ uint8_t MAX3421e< SPI_SS, INTR >::Task(void) {
         //    }
         //    usbSM();                                //USB state machine
         return ( rcode);
+        */
+        busprobe();
+        return 0;
 }
 
 template< typename SPI_SS, typename INTR >


### PR DESCRIPTION
I like to share this `busprobe()` patch and need code review and your thought on it.

Seems like MAX3421e `CONDETIRQ`(Connect/Disconnect Interrupt) doesn't arise for every plugin event and the chip fails to detect it sometimes.  (Meanwhile, I never seen the chip failed in detection of unpluging.)

For confirmaion I tried to catch INT pin change and read bus state immedately using `ISR()`, but it still failed to detect device insertion event occasionally. So I believe that we cannot rely solely on the `CONDETIRQ` interrupt for plugin detection.

This patch checks bus state at every `Task()` call when `vbusState` is  `SE0`(no device) regardless of INT pin.
There are some descriptions of the fix here also. https://github.com/tmk/USB_Host_Shield_2.0/issues/9

These issues are related probably. felis#425 felis#452