### PR TITLE
Restore support for Nintendo RVL-CNT-01	(old wiimote revisions).

### DIFF
--- a/BTD.cpp
+++ b/BTD.cpp
@@ -524,7 +524,7 @@ void BTD::HCI_event_task() {
                                                 D_PrintHex<uint8_t > (classOfDevice[0], 0x80);
 #endif
 
-                                                if(pairWithWii && (classOfDevice[2] == 0x00) && ((classOfDevice[1] & 0x0F) == 0x05) && (classOfDevice[0] & 0x04)) { // See http://wiibrew.org/wiki/Wiimote#SDP_information
+                                                if(pairWithWii && (classOfDevice[2] == 0x00) && ((classOfDevice[1] & 0x0F) == 0x05) && (classOfDevice[0] & 0x0C)) { // See http://wiibrew.org/wiki/Wiimote#SDP_information
                                                         checkRemoteName = true; // Check remote name to distinguish between the different controllers
 
                                                         for(uint8_t j = 0; j < 6; j++)


### PR DESCRIPTION
#### Problem Description
Commit 30ac619331fd43cbbc12150dc244a2457b733566 inadvertently removed the ability to detect OLD Wiimotes.

![image](https://user-images.githubusercontent.com/35271794/136586909-0149d822-d6a9-46de-8d70-8eb154537549.png)

![image](https://user-images.githubusercontent.com/35271794/136588588-fc3e0e52-9524-403f-baf6-b809cdeff60c.png)

In the previous revision, `0x25 & 0x05` would evaluate to true.

The boxed logic in the code screenshot will not recognize Nintendo RVL-CNT-01's reported class, as documented in the [wiibrew wiki](http://wiibrew.org/wiki/Wiimote#SDP_information) link provided by the code, since the middle byte of the class is not 0x05 on the older wiimotes.

#### Proposed changes 
- Match the masking logic added in following lines in  30ac619331fd43cbbc12150dc244a2457b733566.  Not sure if this was always meant to match, or if the logic was simplified here without testing against the older controllers.
    - `((classOfDevice[1] & 0x0F) == 0x05)` 
- Add some parenthesis to the other masks to improve readability of the logic.