### PR TITLE
Fix for non-zero CN issue(#688)

### DIFF
--- a/usbh_midi.cpp
+++ b/usbh_midi.cpp
@@ -1,7 +1,7 @@
 /*
  *******************************************************************************
  * USB-MIDI class driver for USB Host Shield 2.0 Library
- * Copyright (c) 2012-2021 Yuuichi Akagawa
+ * Copyright (c) 2012-2022 Yuuichi Akagawa
  *
  * Idea from LPK25 USB-MIDI to Serial MIDI converter
  *   by Collin Cunningham - makezine.com, narbotic.com
@@ -359,7 +359,7 @@ RecvData_return_from_buffer:
         *(outBuf++) =     recvBuf[readPtr++];
         *(outBuf++) =     recvBuf[readPtr++];
 
-        return getMsgSizeFromCin(cin);
+        return getMsgSizeFromCin(cin & 0x0f);
 }
 
 /* Send data to MIDI device */

--- a/usbh_midi.h
+++ b/usbh_midi.h
@@ -1,7 +1,7 @@
 /*
  *******************************************************************************
  * USB-MIDI class driver for USB Host Shield 2.0 Library
- * Copyright (c) 2012-2021 Yuuichi Akagawa
+ * Copyright (c) 2012-2022 Yuuichi Akagawa
  *
  * Idea from LPK25 USB-MIDI to Serial MIDI converter
  *   by Collin Cunningham - makezine.com, narbotic.com
@@ -28,7 +28,7 @@
 #define _USBH_MIDI_H_
 #include "Usb.h"
 
-#define USBH_MIDI_VERSION 600
+#define USBH_MIDI_VERSION 601
 #define MIDI_MAX_ENDPOINTS 3 //endpoint 0, bulk_IN(MIDI), bulk_OUT(MIDI)
 #define USB_SUBCLASS_MIDISTREAMING 3
 #define MIDI_EVENT_PACKET_SIZE 64


### PR DESCRIPTION
If the CableNumber(CN) is non-zero, RecvData () responds with the wrong message size.
Changed the method to get MIDI message size in version 0.6.0, but the argument was wrong.

In the first byte of the MIDI Event packet, CN is the upper 4 bits and CIN is the lower 4 bits.
Only the lower 4 bits must be given to getMsgSizeFromCin().