### PR TITLE
Add support for MightyCore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           # See: https://travis-ci.org/github/felis/USB_Host_Shield_2.0/jobs/743787235
           if [[ "${{ matrix.example }}" != *"bidirectional_converter" ]]; then TEENSY35="--board=teensy35"; TEENSY36="--board=teensy36"; TEENSY40="--board=teensy40"; TEENSY41="--board=teensy41"; fi
 
-          pio ci --lib="." $UNO --board=genuino101 --board=teensylc $TEENSY40 $TEENSY41
+          pio ci --lib="." $UNO --board=genuino101 --board=ATmega32 --board=teensylc $TEENSY40 $TEENSY41
 
           # Ignore warning caused by strcpy in the ESP8266 core
           pio ci --lib="." --board=esp12e --board=nodemcu --project-option="build_flags=-Wno-array-bounds -Wno-restrict -Wno-stringop-overflow"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Currently the following boards are supported by the library:
 * Balanduino
 * Sanguino
 * Black Widdow
+* Any board supported by [MightyCore](https://github.com/MCUdude/MightyCore)
 * RedBearLab nRF51822
 * Adafruit Feather nRF52840 Express
 * Digilent chipKIT

--- a/UsbCore.h
+++ b/UsbCore.h
@@ -50,6 +50,8 @@ typedef MAX3421e<P3, P2> MAX3421E; // The Intel Galileo supports much faster rea
 typedef MAX3421e<P15, P5> MAX3421E; // ESP8266 boards
 #elif defined(ESP32)
 typedef MAX3421e<P5, P17> MAX3421E; // ESP32 boards
+#elif defined(MIGHTYCORE)
+typedef MAX3421e<Pb4, Pb3> MAX3421E; // MightyCore
 #elif (defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284P__))
 typedef MAX3421e<Pb4, Pb3> MAX3421E; // Sanguino
 #else

--- a/avrpins.h
+++ b/avrpins.h
@@ -765,44 +765,6 @@ public:
 #define P31 Pd7
 // UNO*Pro
 
-#elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__)
-// Sanguino pin numbers
-// Homepage: http://sanguino.cc/hardware
-// Hardware add-on: https://github.com/Lauszus/Sanguino
-#define P0  Pb0
-#define P1  Pb1
-#define P2  Pb2
-#define P3  Pb3
-#define P4  Pb4
-#define P5  Pb5
-#define P6  Pb6
-#define P7  Pb7
-#define P8  Pd0
-#define P9  Pd1
-#define P10 Pd2
-#define P11 Pd3
-#define P12 Pd4
-#define P13 Pd5
-#define P14 Pd6
-#define P15 Pd7
-#define P16 Pc0
-#define P17 Pc1
-#define P18 Pc2
-#define P19 Pc3
-#define P20 Pc4
-#define P21 Pc5
-#define P22 Pc6
-#define P23 Pc7
-#define P24 Pa0
-#define P25 Pa1
-#define P26 Pa2
-#define P27 Pa3
-#define P28 Pa4
-#define P29 Pa5
-#define P30 Pa6
-#define P31 Pa7
-// Sanguino
-
 #elif defined(MIGHTYCORE)
 // https://github.com/MCUdude/MightyCore
 #if defined(BOBUINO_PINOUT)
@@ -884,6 +846,44 @@ public:
   #endif
 #endif
 // MightyCore
+
+#elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__)
+// Sanguino pin numbers
+// Homepage: http://sanguino.cc/hardware
+// Hardware add-on: https://github.com/Lauszus/Sanguino
+#define P0  Pb0
+#define P1  Pb1
+#define P2  Pb2
+#define P3  Pb3
+#define P4  Pb4
+#define P5  Pb5
+#define P6  Pb6
+#define P7  Pb7
+#define P8  Pd0
+#define P9  Pd1
+#define P10 Pd2
+#define P11 Pd3
+#define P12 Pd4
+#define P13 Pd5
+#define P14 Pd6
+#define P15 Pd7
+#define P16 Pc0
+#define P17 Pc1
+#define P18 Pc2
+#define P19 Pc3
+#define P20 Pc4
+#define P21 Pc5
+#define P22 Pc6
+#define P23 Pc7
+#define P24 Pa0
+#define P25 Pa1
+#define P26 Pa2
+#define P27 Pa3
+#define P28 Pa4
+#define P29 Pa5
+#define P30 Pa6
+#define P31 Pa7
+// Sanguino
 
 #else
 #error "Please define board in avrpins.h"

--- a/avrpins.h
+++ b/avrpins.h
@@ -803,6 +803,88 @@ public:
 #define P31 Pa7
 // Sanguino
 
+#elif defined(MIGHTYCORE)
+// https://github.com/MCUdude/MightyCore
+#if defined(BOBUINO_PINOUT)
+  #define P0  Pd0
+  #define P1  Pd1
+  #define P2  Pd2
+  #define P3  Pd3
+  #define P4  Pb0
+  #define P5  Pb1
+  #define P6  Pb2
+  #define P7  Pb3
+  #define P8  Pd5
+  #define P9  Pd6
+  #define P10 Pb4
+  #define P11 Pb5
+  #define P12 Pb6
+  #define P13 Pb7
+  #define P14 Pa7
+  #define P15 Pa6
+  #define P16 Pa5
+  #define P17 Pa4
+  #define P18 Pa3
+  #define P19 Pa2
+  #define P20 Pa1
+  #define P21 Pa0
+  #define P22 Pc0
+  #define P23 Pc1
+  #define P24 Pc2
+  #define P25 Pc3
+  #define P26 Pc4
+  #define P27 Pc5
+  #define P28 Pc6
+  #define P29 Pc7
+  #define P30 Pd4
+  #define P31 Pd7
+#else
+  #define P0  Pb0
+  #define P1  Pb1
+  #define P2  Pb2
+  #define P3  Pb3
+  #define P4  Pb4
+  #define P5  Pb5
+  #define P6  Pb6
+  #define P7  Pb7
+  #define P8  Pd0
+  #define P9  Pd1
+  #define P10 Pd2
+  #define P11 Pd3
+  #define P12 Pd4
+  #define P13 Pd5
+  #define P14 Pd6
+  #define P15 Pd7
+  #define P16 Pc0
+  #define P17 Pc1
+  #define P18 Pc2
+  #define P19 Pc3
+  #define P20 Pc4
+  #define P21 Pc5
+  #define P22 Pc6
+  #define P23 Pc7
+  #if defined(SANGUINO_PINOUT)
+    #define P24 Pa7
+    #define P25 Pa6
+    #define P26 Pa5
+    #define P27 Pa4
+    #define P28 Pa3
+    #define P29 Pa2
+    #define P30 Pa1
+    #define P31 Pa0
+  #else
+    #define P24 Pa0
+    #define P25 Pa1
+    #define P26 Pa2
+    #define P27 Pa3
+    #define P28 Pa4
+    #define P29 Pa5
+    #define P30 Pa6
+    #define P31 Pa7
+  #endif
+#endif
+// MightyCore
+
 #else
 #error "Please define board in avrpins.h"
 


### PR DESCRIPTION
This adds support for [MightyCore](https://github.com/MCUdude/MightyCore), an Arduino core for a number of larger 32 I/O AVR microcontrollers.

It has 3 selectable pin mapping configurations for compatibility with some other boards. This change should support all 3, though I've only actually tested the "standard" configuration.