### PR TITLE
Removed trailing comma in library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
   [
     {
       "name": "Oleg Mazurov",
-      "email": "mazurov@gmail.com",
+      "email": "mazurov@gmail.com"
     },
     {
       "name": "Alexei Glushchenko",


### PR DESCRIPTION
Fixes Library Manager warning:
Library Manager: Could not parse manifest -> Expecting property name enclosed in double quotes: line 10 column 5 (char 332)