### PR TITLE
Add functionality to retrieve input source from MiniDSP 2x4HD

### DIFF
--- a/MiniDSP.h
+++ b/MiniDSP.h
@@ -39,6 +39,13 @@
 class MiniDSP : public HIDUniversal {
 public:
 
+        enum class InputSource {
+                ANALOG = 0x00,
+                TOSLINK = 0x01,
+                USB = 0x02,
+                UNKNOWN = 0x03
+        };
+
         /**
          * Constructor for the MiniDSP class.
          * @param  p   Pointer to the USB class instance.
@@ -81,6 +88,14 @@ public:
          */
         void attachOnMutedChange(void (*funcOnMutedChange)(bool)) {
                 pFuncOnMutedChange = funcOnMutedChange;
+        }
+
+        /**
+         * Used to call your own function when the input source has changed.
+         * @param funcOnInputSourceChange Function to call.
+         */
+        void attachOnInputSourceChange(void (*funcOnInputSourceChange)(InputSource)) {
+                pFuncOnInputSourceChange = funcOnInputSourceChange;
         }
 
         /**
@@ -159,6 +174,9 @@ private:
         void
         RequestStatus() const;
 
+        void
+        RequestInputSource() const;
+
         /**
          * Send the given MiniDSP command. This function will create a buffer
          * with the expected header and checksum and send it to the MiniDSP.
@@ -179,6 +197,9 @@ private:
         // Pointer to function called when muted status changes.
         void (*pFuncOnMutedChange)(bool) = nullptr;
 
+        // Pointer to function called when input source changes.
+        void (*pFuncOnInputSourceChange)(InputSource) = nullptr;
+
         // -----------------------------------------------------------------------------
 
         // MiniDSP state. Currently only volume and muted status are
@@ -188,4 +209,5 @@ private:
         // -dB value. Example: 19 represents -9.5dB.
         uint8_t volume = 0;
         bool muted = false;
+        InputSource inputSource = InputSource::UNKNOWN;
 };

--- a/MiniDSP.h
+++ b/MiniDSP.h
@@ -124,6 +124,10 @@ public:
                 return muted;
         }
 
+        InputSource getInputSource() const {
+                return inputSource;
+        }
+
 protected:
         /** @name HIDUniversal implementation */
         /**

--- a/MiniDSP.h
+++ b/MiniDSP.h
@@ -117,13 +117,17 @@ public:
         }
 
         /**
-         * Retrieve the current muted status of the MiniDSP
+         * Retrieve the current muted status of the MiniDSP.
          * @return `true` if the device is muted, `false` otherwise.
          */
         bool isMuted() const {
                 return muted;
         }
 
+        /**
+         * Retrieve the current input source of the MiniDSP.
+         * @return Current input source: `ANALOG`, `TOSLINK` or `USB`.
+         */
         InputSource getInputSource() const {
                 return inputSource;
         }

--- a/examples/MiniDSP/MiniDSP.ino
+++ b/examples/MiniDSP/MiniDSP.ino
@@ -25,6 +25,20 @@ void OnMutedChange(bool isMuted) {
   Serial.println("Muted status: " + String(isMuted ? "muted" : "unmuted"));
 }
 
+void OnInputSourceChange(MiniDSP::InputSource inputSource) {
+  String inputSourceStr;
+
+  if(inputSource == MiniDSP::InputSource::ANALOG) {
+    inputSourceStr = "Analog";
+  } else if(inputSource == MiniDSP::InputSource::TOSLINK) {
+    inputSourceStr = "Toslink";
+  } else if(inputSource == MiniDSP::InputSource::USB) {
+    inputSourceStr = "USB";
+  }
+
+  Serial.println("Input source: " + inputSourceStr);
+}
+
 void setup() {
   Serial.begin(115200);
 #if !defined(__MIPSEL__)
@@ -40,6 +54,7 @@ void setup() {
   MiniDSP.attachOnInit(&OnMiniDSPConnected);
   MiniDSP.attachOnVolumeChange(&OnVolumeChange);
   MiniDSP.attachOnMutedChange(&OnMutedChange);
+  MiniDSP.attachOnInputSourceChange(&OnInputSourceChange);
 }
 
 void loop() {


### PR DESCRIPTION
Additional functionality for the MiniDSP driver.

Next to volume and muted status, it can now also retrieve the current input source (Analog, Toslink or USB).