### PR TITLE
Add support for Seeed XIAO nRF52840 Sense Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Currently the following boards are supported by the library:
 * Any board supported by [MightyCore](https://github.com/MCUdude/MightyCore)
 * RedBearLab nRF51822
 * Adafruit Feather nRF52840 Express
+* SEEED XIAO nRF52840 Sense
+    * Note it uses pin 7 and 5 for SS and INT respectively
 * Digilent chipKIT
     * Please see: <https://chome.nerpa.tech/mcu/usb/running-usb-host-code-on-digilent-chipkit-board>.
 * STM32F4

--- a/UsbCore.h
+++ b/UsbCore.h
@@ -50,6 +50,8 @@ typedef MAX3421e<P3, P2> MAX3421E; // The Intel Galileo supports much faster rea
 typedef MAX3421e<P15, P5> MAX3421E; // ESP8266 boards
 #elif defined(ESP32)
 typedef MAX3421e<P5, P17> MAX3421E; // ESP32 boards
+#elif defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
+typedef MAX3421e<P7, P5> MAX3421E; // Seeed_XIAO_nRF52840_Sense
 #elif defined(MIGHTYCORE)
 typedef MAX3421e<Pb4, Pb3> MAX3421E; // MightyCore
 #elif (defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284P__))

--- a/avrpins.h
+++ b/avrpins.h
@@ -1438,6 +1438,68 @@ MAKE_PIN(P33, (9));
 
 #undef MAKE_PIN
 
+
+
+#elif defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
+
+#define MAKE_PIN(className, pin) \
+class className { \
+public: \
+    static void Set() { \
+        nrf_gpio_pin_set(pin); \
+    } \
+    static void Clear() { \
+        nrf_gpio_pin_clear(pin); \
+    } \
+    static void SetDirRead() { \
+        nrf_gpio_cfg_input(pin, NRF_GPIO_PIN_NOPULL); \
+    } \
+    static void SetDirWrite() { \
+        nrf_gpio_cfg_output(pin); \
+    } \
+    static uint8_t IsSet() { \
+        return (uint8_t)nrf_gpio_pin_read(pin); \
+    } \
+};
+
+// Based on variants/feather_nrf52840_express/variant.cpp
+// g_ADigitalPinMap could be used directly, but it would be slower
+MAKE_PIN(P0, (2));
+MAKE_PIN(P1, (3));
+MAKE_PIN(P2, (28));
+MAKE_PIN(P3, (29));
+MAKE_PIN(P4, (4));
+MAKE_PIN(P5, (5));
+MAKE_PIN(P6, (43));
+MAKE_PIN(P7, (44));
+MAKE_PIN(P8, (45));
+MAKE_PIN(P9, (46));
+MAKE_PIN(P10, (47));
+MAKE_PIN(P11, (26));
+MAKE_PIN(P12, (6));
+MAKE_PIN(P13, (30));
+MAKE_PIN(P14, (14));
+MAKE_PIN(P15, (40));
+MAKE_PIN(P17, (27));
+MAKE_PIN(P18, (7));
+MAKE_PIN(P16, (11));
+MAKE_PIN(P19, (42));
+MAKE_PIN(P20, (32));
+MAKE_PIN(P21, (16));
+MAKE_PIN(P22, (13));
+MAKE_PIN(P23, (17));
+MAKE_PIN(P24, (21));
+MAKE_PIN(P25, (25));
+MAKE_PIN(P26, (20));
+MAKE_PIN(P27, (24));
+MAKE_PIN(P28, (22));
+MAKE_PIN(P29, (23));
+MAKE_PIN(P30, (9));
+MAKE_PIN(P31, (10));
+MAKE_PIN(P32, (31));
+
+#undef MAKE_PIN
+
 #else
 #error "Please define board in avrpins.h"
 

--- a/examples/HID/scale/scale_rptparser.cpp
+++ b/examples/HID/scale/scale_rptparser.cpp
@@ -1,4 +1,4 @@
-#if defined(ARDUINO_SAM_DUE) || defined(ARDUINO_NRF52840_FEATHER)
+#if defined(ARDUINO_SAM_DUE) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
 #include <avr/dtostrf.h>
 #endif
 

--- a/usbhost.h
+++ b/usbhost.h
@@ -122,6 +122,8 @@ typedef SPi< P14, P13, P12, P15 > spi;
 typedef SPi< P18, P23, P19, P5 > spi;
 #elif defined(ARDUINO_NRF52840_FEATHER)
 typedef SPi< P26, P25, P24, P5 > spi;
+#elif defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
+typedef SPi< P8, P10, P9, P7 > spi;
 #else
 #error "No SPI entry in usbhost.h"
 #endif


### PR DESCRIPTION
Seems to work fine with the `board_qc` example.