### PR TITLE
HID/scale: fix invalid extended char

### DIFF
--- a/examples/HID/scale/scale_rptparser.cpp
+++ b/examples/HID/scale/scale_rptparser.cpp
@@ -1,4 +1,4 @@
-#if defined(ARDUINO_SAM_DUE) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
+#if defined(ARDUINO_SAM_DUE) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
 #include <avr/dtostrf.h>
 #endif
 


### PR DESCRIPTION
This patch fixes the following error that happens during the automatic build of the project by github CI by removing the spurious (not visible) invalid char.

src/scale_rptparser.cpp:1:69: error: extended character   is not valid in an identifier
    1 | #if defined(ARDUINO_SAM_DUE) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
      |                                                                     ^
src/scale_rptparser.cpp:1:77: error: missing binary operator before token "("
    1 | #if defined(ARDUINO_SAM_DUE) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
      |                                                                             ^
*** [.pio/build/teensy40/src/scale_rptparser.cpp.o] Error 1