### PR TITLE
Added the pin definitions to support the m5 usb model on m5stack s3

### DIFF
--- a/UsbCore.h
+++ b/UsbCore.h
@@ -48,6 +48,8 @@ typedef MAX3421e<P20, P19> MAX3421E; // Balanduino
 typedef MAX3421e<P3, P2> MAX3421E; // The Intel Galileo supports much faster read and write speed at pin 2 and 3
 #elif defined(ESP8266)
 typedef MAX3421e<P15, P5> MAX3421E; // ESP8266 boards
+#elif defined(ARDUINO_M5STACK_CORES3)
+typedef MAX3421e<P1, P14> MAX3421E; // M5Stack Core S3
 #elif defined(ARDUINO_XIAO_ESP32S3)
 typedef MAX3421e<P44, P4> MAX3421E; // ESP32 XIAO boards
 #elif defined(ESP32)

--- a/avrpins.h
+++ b/avrpins.h
@@ -1852,6 +1852,47 @@ MAKE_PIN(P13, 13); // MOSI
 MAKE_PIN(P14, 14); // SCK
 MAKE_PIN(P15, 15); // SS
 
+#elif defined(ARDUINO_M5STACK_CORES3)
+
+// Workaround strict-aliasing warnings
+#ifdef pgm_read_word
+#undef pgm_read_word
+#endif
+#ifdef pgm_read_dword
+#undef pgm_read_dword
+#endif
+#ifdef  pgm_read_float
+#undef pgm_read_float
+#endif
+#ifdef  pgm_read_ptr
+#undef pgm_read_ptr
+#endif
+
+#define pgm_read_word(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const unsigned short *)(_addr); \
+})
+#define pgm_read_dword(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const unsigned long *)(_addr); \
+})
+#define pgm_read_float(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const float *)(_addr); \
+})
+#define pgm_read_ptr(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(void * const *)(_addr); \
+})
+
+// Pinout for ESP32 dev module
+
+MAKE_PIN(P35, 35); // MISO
+MAKE_PIN(P37, 37); // MOSI
+MAKE_PIN(P36, 36); // SCK
+MAKE_PIN(P1, 1); // SS
+MAKE_PIN(P14, 14); // INT
+
 #elif defined(ARDUINO_XIAO_ESP32S3)
 
 // Workaround strict-aliasing warnings

--- a/usbhost.h
+++ b/usbhost.h
@@ -118,6 +118,8 @@ typedef SPi< P76, P75, P74, P10 > spi;
 typedef SPi< P16, P18, P17, P10 > spi;
 #elif defined(ESP8266)
 typedef SPi< P14, P13, P12, P15 > spi;
+#elif defined(ARDUINO_M5STACK_CORES3)
+typedef SPi< P36, P37, P35, P1 > spi;
 #elif defined(ARDUINO_XIAO_ESP32S3)
 typedef SPi< P7, P9, P8, P44 > spi;
 #elif defined(ESP32)


### PR DESCRIPTION
This change will allow support for the m5 stack core s3 and the USB v1.2 module.

This assumes CH2 is selected on for both SS and INT on the dip switches.

The change has been tested on the M5 Stack CoreS3 only.

Fixes #841