### PR TITLE
Remove the protocol mask as this limits 0x00.

### DIFF
--- a/cdcacm.cpp
+++ b/cdcacm.cpp
@@ -136,8 +136,7 @@ uint8_t ACM::Init(uint8_t parent, uint8_t port, bool lowspeed) {
                         CDC_SUBCLASS_ACM,
                         CDC_PROTOCOL_ITU_T_V_250,
                         CP_MASK_COMPARE_CLASS |
-                        CP_MASK_COMPARE_SUBCLASS |
-                        CP_MASK_COMPARE_PROTOCOL > CdcControlParser(this);
+                        CP_MASK_COMPARE_SUBCLASS > CdcControlParser(this);
 
                 ConfigDescParser<USB_CLASS_CDC_DATA, 0, 0,
                         CP_MASK_COMPARE_CLASS> CdcDataParser(this);


### PR DESCRIPTION
This will now also allow the following.

// Protocol 0x02 - PCCA-101 AT commands (different command set)
// Protocol 0x04 - GSM 7.07 (mobile-specific commands)
// Protocol 0x07 - USB Ethernet Emulation (completely different purpose)

however in real life having these subprotocols accepted under the CDC_ACM subprotocol and being an issue is unlikely.

More common that somebody just wants some basic serial with a uC with inbuild usb support.

Tested on M5 Stack CoreS3 only.

Fixes #842