### PR TITLE
Add ESP32-S2 and ESP32-S3 support

### DIFF
--- a/AMBX.cpp
+++ b/AMBX.cpp
@@ -18,8 +18,8 @@
 // To enable serial debugging see "settings.h"
 //#define EXTRADEBUG // Uncomment to get even more debugging data
 
-AMBX::AMBX(USB *p) :
-pUsb(p), // pointer to USB class instance - mandatory
+AMBX::AMBX(USBHost *p) :
+pUsb(p), // pointer to USBHost class instance - mandatory
 bAddress(0) // device address - mandatory
 {
         for(uint8_t i = 0; i < AMBX_MAX_ENDPOINTS; i++) {
@@ -30,7 +30,7 @@ bAddress(0) // device address - mandatory
                 epInfo[i].bmNakPower = (i) ? USB_NAK_NOWAIT : USB_NAK_MAX_POWER;
         }
 
-        if(pUsb) // register in USB subsystem
+        if(pUsb) // register in USBHost subsystem
                 pUsb->RegisterDeviceClass(this); //set devConfig[] entry
 }
 
@@ -43,7 +43,7 @@ uint8_t AMBX::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         uint16_t PID;
         uint16_t VID;
 
-        // get memory address of USB device address pool
+        // get memory address of USBHost device address pool
         AddressPool &addrPool = pUsb->GetAddressPool();
 #ifdef EXTRADEBUG
         Notify(PSTR("\r\nAMBX Init"), 0x80);

--- a/AMBX.h
+++ b/AMBX.h
@@ -21,7 +21,7 @@
 #include "AMBXEnums.h"
 
 /* AMBX data taken from descriptors */
-#define AMBX_EP_MAXPKTSIZE           40 // max size for data via USB
+#define AMBX_EP_MAXPKTSIZE           40 // max size for data via USBHost
 
 /* Names we give to the 3 AMBX but note only one is actually used (output) */
 #define AMBX_CONTROL_PIPE        0
@@ -64,9 +64,9 @@ class AMBX : public USBDeviceConfig {
 public:
         /**
          * Constructor for the AMBX class.
-         * @param  pUsb   Pointer to USB class instance.
+         * @param  pUsb   Pointer to USBHost class instance.
          */
-        AMBX(USB *pUsb);
+        AMBX(USBHost *pUsb);
 
         /** @name USBDeviceConfig implementation */
         /**
@@ -78,12 +78,12 @@ public:
          */
         uint8_t Init(uint8_t parent, uint8_t port, bool lowspeed);
         /**
-         * Release the USB device.
+         * Release the USBHost device.
          * @return 0 on success.
          */
         uint8_t Release();
         /**
-         * Poll the USB Input endpoins and run the state machines.
+         * Poll the USBHost Input endpoins and run the state machines.
          * @return 0 on success.
          */
         uint8_t Poll();
@@ -97,7 +97,7 @@ public:
         };
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.
@@ -136,8 +136,8 @@ public:
         bool AMBXConnected;
 
 protected:
-        /** Pointer to USB class instance. */
-        USB *pUsb;
+        /** Pointer to USBHost class instance. */
+        USBHost *pUsb;
         /** Device address. */
         uint8_t bAddress;
         /** Endpoint info structure. */

--- a/BTD.cpp
+++ b/BTD.cpp
@@ -24,13 +24,13 @@ const uint8_t BTD::BTD_EVENT_PIPE = 1;
 const uint8_t BTD::BTD_DATAIN_PIPE = 2;
 const uint8_t BTD::BTD_DATAOUT_PIPE = 3;
 
-BTD::BTD(USB *p) :
+BTD::BTD(USBHost *p) :
 connectToWii(false),
 pairWithWii(false),
 connectToHIDDevice(false),
 pairWithHIDDevice(false),
 useSimplePairing(false),
-pUsb(p), // Pointer to USB class instance - mandatory
+pUsb(p), // Pointer to USBHost class instance - mandatory
 bAddress(0), // Device address - mandatory
 bNumEP(1), // If config descriptor needs to be parsed
 qNextPollTime(0), // Reset NextPollTime
@@ -43,7 +43,7 @@ bPollEnable(false) // Don't start polling before dongle is connected
 
         Initialize(); // Set all variables, endpoint structs etc. to default values
 
-        if(pUsb) // Register in USB subsystem
+        if(pUsb) // Register in USBHost subsystem
                 pUsb->RegisterDeviceClass(this); // Set devConfig[] entry
 }
 
@@ -57,7 +57,7 @@ uint8_t BTD::ConfigureDevice(uint8_t parent, uint8_t port, bool lowspeed) {
 
         Initialize(); // Set all variables, endpoint structs etc. to default values
 
-        AddressPool &addrPool = pUsb->GetAddressPool(); // Get memory address of USB device address pool
+        AddressPool &addrPool = pUsb->GetAddressPool(); // Get memory address of USBHost device address pool
 #ifdef EXTRADEBUG
         Notify(PSTR("\r\nBTD ConfigureDevice"), 0x80);
 #endif
@@ -103,7 +103,7 @@ uint8_t BTD::ConfigureDevice(uint8_t parent, uint8_t port, bool lowspeed) {
                 return USB_ERROR_OUT_OF_ADDRESS_SPACE_IN_POOL;
         }
 
-        if (udd->bDeviceClass == 0x09) // Some dongles have an USB hub inside
+        if (udd->bDeviceClass == 0x09) // Some dongles have an USBHost hub inside
                 goto FailHub;
 
         epInfo[0].maxPktSize = udd->bMaxPacketSize0; // Extract Max Packet Size from device descriptor

--- a/BTD.h
+++ b/BTD.h
@@ -216,16 +216,16 @@
 class BluetoothService;
 
 /**
- * The Bluetooth Dongle class will take care of all the USB communication
+ * The Bluetooth Dongle class will take care of all the USBHost communication
  * and then pass the data to the BluetoothService classes.
  */
 class BTD : public USBDeviceConfig, public UsbConfigXtracter {
 public:
         /**
          * Constructor for the BTD class.
-         * @param  p   Pointer to USB class instance.
+         * @param  p   Pointer to USBHost class instance.
          */
-        BTD(USB *p);
+        BTD(USBHost *p);
 
         /** @name USBDeviceConfig implementation */
         /**
@@ -245,12 +245,12 @@ public:
          */
         uint8_t Init(uint8_t parent, uint8_t port, bool lowspeed);
         /**
-         * Release the USB device.
+         * Release the USBHost device.
          * @return 0 on success.
          */
         uint8_t Release();
         /**
-         * Poll the USB Input endpoints and run the state machines.
+         * Poll the USBHost Input endpoints and run the state machines.
          * @return 0 on success.
          */
         uint8_t Poll();
@@ -272,16 +272,16 @@ public:
         };
 
         /**
-         * Used by the USB core to check what this driver support.
-         * @param  klass The device's USB class.
-         * @return       Returns true if the device's USB class matches this driver.
+         * Used by the USBHost core to check what this driver support.
+         * @param  klass The device's USBHost class.
+         * @return       Returns true if the device's USBHost class matches this driver.
          */
         virtual bool DEVCLASSOK(uint8_t klass) {
                 return (klass == USB_CLASS_WIRELESS_CTRL);
         };
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * Used to set the Bluetooth address into the PS3 controllers.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
@@ -535,8 +535,8 @@ public:
         bool useSimplePairing;
 
 protected:
-        /** Pointer to USB class instance. */
-        USB *pUsb;
+        /** Pointer to USBHost class instance. */
+        USBHost *pUsb;
         /** Device address. */
         uint8_t bAddress;
         /** Endpoint info structure. */
@@ -546,7 +546,7 @@ protected:
         uint8_t bConfNum;
         /** Total number of endpoints in the configuration. */
         uint8_t bNumEP;
-        /** Next poll time based on poll interval taken from the USB descriptor. */
+        /** Next poll time based on poll interval taken from the USBHost descriptor. */
         uint32_t qNextPollTime;
 
         /** Bluetooth dongle control endpoint. */
@@ -559,8 +559,8 @@ protected:
         static const uint8_t BTD_DATAOUT_PIPE;
 
         /**
-         * Used to print the USB Endpoint Descriptor.
-         * @param ep_ptr Pointer to USB Endpoint Descriptor.
+         * Used to print the USBHost Endpoint Descriptor.
+         * @param ep_ptr Pointer to USBHost Endpoint Descriptor.
          */
         void PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr);
 

--- a/BTHID.cpp
+++ b/BTHID.cpp
@@ -21,7 +21,7 @@
 //#define PRINTREPORT // Uncomment to print the report send by the HID device
 
 BTHID::BTHID(BTD *p, bool pair, const char *pin) :
-BluetoothService(p), // Pointer to USB class instance - mandatory
+BluetoothService(p), // Pointer to USBHost class instance - mandatory
 protocolMode(USB_HID_BOOT_PROTOCOL) {
         for(uint8_t i = 0; i < NUM_PARSERS; i++)
                 pRptParser[i] = NULL;
@@ -345,12 +345,12 @@ void BTHID::ACLData(uint8_t* l2capinbuf) {
                                 switch(l2capinbuf[9]) { // Report ID
                                         case 0x01: // Keyboard or Joystick events
                                                 if(pRptParser[KEYBOARD_PARSER_ID])
-                                                        pRptParser[KEYBOARD_PARSER_ID]->Parse(reinterpret_cast<USBHID *>(this), 0, (uint8_t)(length - 2), &l2capinbuf[10]); // Use reinterpret_cast again to extract the instance
+                                                        pRptParser[KEYBOARD_PARSER_ID]->Parse(reinterpret_cast<HostUSBHID *>(this), 0, (uint8_t)(length - 2), &l2capinbuf[10]); // Use reinterpret_cast again to extract the instance
                                                 break;
 
                                         case 0x02: // Mouse events
                                                 if(pRptParser[MOUSE_PARSER_ID])
-                                                        pRptParser[MOUSE_PARSER_ID]->Parse(reinterpret_cast<USBHID *>(this), 0, (uint8_t)(length - 2), &l2capinbuf[10]); // Use reinterpret_cast again to extract the instance
+                                                        pRptParser[MOUSE_PARSER_ID]->Parse(reinterpret_cast<HostUSBHID *>(this), 0, (uint8_t)(length - 2), &l2capinbuf[10]); // Use reinterpret_cast again to extract the instance
                                                 break;
 #ifdef EXTRADEBUG
                                         default:

--- a/MiniDSP.cpp
+++ b/MiniDSP.cpp
@@ -21,7 +21,7 @@
 
 #include "MiniDSP.h"
 
-void MiniDSP::ParseHIDData(USBHID *hid __attribute__ ((unused)), bool is_rpt_id __attribute__ ((unused)), uint8_t len, uint8_t *buf) {
+void MiniDSP::ParseHIDData(HostUSBHID *hid __attribute__ ((unused)), bool is_rpt_id __attribute__ ((unused)), uint8_t len, uint8_t *buf) {
 
         constexpr uint8_t StatusInputCommand[] = {0x05, 0xFF, 0xDA};
 

--- a/MiniDSP.h
+++ b/MiniDSP.h
@@ -27,23 +27,23 @@
 #define MINIDSP_PID 0x0011 // MiniDSP 2x4HD
 
 /**
- * Arduino MiniDSP 2x4HD USB Host Driver by Dennis Frett.
+ * Arduino MiniDSP 2x4HD USBHost Host Driver by Dennis Frett.
  *
- * This class implements support for the MiniDSP 2x4HD via USB.
+ * This class implements support for the MiniDSP 2x4HD via USBHost.
  * Based on NodeJS implementation by Mathieu Rene:
  * https://github.com/mrene/node-minidsp and the Python implementation by Mark
  * Kubiak: https://github.com/markubiak/python3-minidsp.
  *
- * It uses the HIDUniversal class for all the USB communication.
+ * It uses the HIDUniversal class for all the USBHost communication.
  */
 class MiniDSP : public HIDUniversal {
 public:
 
         /**
          * Constructor for the MiniDSP class.
-         * @param  p   Pointer to the USB class instance.
+         * @param  p   Pointer to the USBHost class instance.
          */
-        MiniDSP(USB *p) : HIDUniversal(p) {
+        MiniDSP(USBHost *p) : HIDUniversal(p) {
         };
 
         /**
@@ -112,13 +112,13 @@ public:
 protected:
         /** @name HIDUniversal implementation */
         /**
-         * Used to parse USB HID data.
+         * Used to parse USBHost HID data.
          * @param hid       Pointer to the HID class.
          * @param is_rpt_id Only used for Hubs.
          * @param len       The length of the incoming data.
          * @param buf       Pointer to the data buffer.
          */
-        void ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+        void ParseHIDData(HostUSBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 
         /**
          * Called when a device is successfully initialized.
@@ -132,7 +132,7 @@ protected:
         /** @name USBDeviceConfig implementation */
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this

--- a/PS3BT.cpp
+++ b/PS3BT.cpp
@@ -21,7 +21,7 @@
 //#define PRINTREPORT // Uncomment to print the report send by the PS3 Controllers
 
 PS3BT::PS3BT(BTD *p, uint8_t btadr5, uint8_t btadr4, uint8_t btadr3, uint8_t btadr2, uint8_t btadr1, uint8_t btadr0) :
-BluetoothService(p) // Pointer to USB class instance - mandatory
+BluetoothService(p) // Pointer to USBHost class instance - mandatory
 {
         pBtd->my_bdaddr[5] = btadr5; // Change to your dongle's Bluetooth address instead
         pBtd->my_bdaddr[4] = btadr4;

--- a/PS3Enums.h
+++ b/PS3Enums.h
@@ -57,7 +57,7 @@ const uint8_t PS3_LEDS[] PROGMEM = {
 
 /**
  * Buttons on the controllers.
- * <B>Note:</B> that the location is shifted 9 when it's connected via USB.
+ * <B>Note:</B> that the location is shifted 9 when it's connected via USBHost.
  */
 const uint32_t PS3_BUTTONS[] PROGMEM = {
         0x10, // UP
@@ -87,7 +87,7 @@ const uint32_t PS3_BUTTONS[] PROGMEM = {
 
 /**
  * Analog buttons on the controllers.
- * <B>Note:</B> that the location is shifted 9 when it's connected via USB.
+ * <B>Note:</B> that the location is shifted 9 when it's connected via USBHost.
  */
 const uint8_t PS3_ANALOG_BUTTONS[] PROGMEM = {
         23, // UP_ANALOG
@@ -111,7 +111,7 @@ const uint8_t PS3_ANALOG_BUTTONS[] PROGMEM = {
 };
 
 enum StatusEnum {
-        // Note that the location is shifted 9 when it's connected via USB
+        // Note that the location is shifted 9 when it's connected via USBHost
         // Byte location | bit location
         Plugged = (38 << 8) | 0x02,
         Unplugged = (38 << 8) | 0x03,
@@ -132,8 +132,8 @@ enum StatusEnum {
         MoveHigh = (21 << 8) | 0x04,
         MoveFull = (21 << 8) | 0x05,
 
-        CableRumble = (40 << 8) | 0x10, // Operating by USB and rumble is turned on
-        Cable = (40 << 8) | 0x12, // Operating by USB and rumble is turned off
+        CableRumble = (40 << 8) | 0x10, // Operating by USBHost and rumble is turned on
+        Cable = (40 << 8) | 0x12, // Operating by USBHost and rumble is turned off
         BluetoothRumble = (40 << 8) | 0x14, // Operating by Bluetooth and rumble is turned on
         Bluetooth = (40 << 8) | 0x16, // Operating by Bluetooth and rumble is turned off
 };

--- a/PS3USB.cpp
+++ b/PS3USB.cpp
@@ -20,8 +20,8 @@
 //#define EXTRADEBUG // Uncomment to get even more debugging data
 //#define PRINTREPORT // Uncomment to print the report send by the PS3 Controllers
 
-PS3USB::PS3USB(USB *p, uint8_t btadr5, uint8_t btadr4, uint8_t btadr3, uint8_t btadr2, uint8_t btadr1, uint8_t btadr0) :
-pUsb(p), // pointer to USB class instance - mandatory
+PS3USB::PS3USB(USBHost *p, uint8_t btadr5, uint8_t btadr4, uint8_t btadr3, uint8_t btadr2, uint8_t btadr1, uint8_t btadr0) :
+pUsb(p), // pointer to USBHost class instance - mandatory
 bAddress(0), // device address - mandatory
 bPollEnable(false) // don't start polling before dongle is connected
 {
@@ -33,7 +33,7 @@ bPollEnable(false) // don't start polling before dongle is connected
                 epInfo[i].bmNakPower = (i) ? USB_NAK_NOWAIT : USB_NAK_MAX_POWER;
         }
 
-        if(pUsb) // register in USB subsystem
+        if(pUsb) // register in USBHost subsystem
                 pUsb->RegisterDeviceClass(this); //set devConfig[] entry
 
         my_bdaddr[5] = btadr5; // Change to your dongle's Bluetooth address instead
@@ -53,7 +53,7 @@ uint8_t PS3USB::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         uint16_t PID;
         uint16_t VID;
 
-        // get memory address of USB device address pool
+        // get memory address of USBHost device address pool
         AddressPool &addrPool = pUsb->GetAddressPool();
 #ifdef EXTRADEBUG
         Notify(PSTR("\r\nPS3USB Init"), 0x80);
@@ -282,7 +282,7 @@ uint8_t PS3USB::Poll() {
                         printReport(); // Uncomment "#define PRINTREPORT" to print the report send by the PS3 Controllers
 #endif
                 }
-        } else if(PS3MoveConnected) { // One can only set the color of the bulb, set the rumble, set and get the bluetooth address and calibrate the magnetometer via USB
+        } else if(PS3MoveConnected) { // One can only set the color of the bulb, set the rumble, set and get the bluetooth address and calibrate the magnetometer via USBHost
                 if((int32_t)((uint32_t)millis() - timer) > 4000) { // Send at least every 4th second
                         Move_Command(writeBuf, MOVE_REPORT_BUFFER_SIZE); // The Bulb and rumble values, has to be written again and again, for it to stay turned on
                         timer = (uint32_t)millis();
@@ -488,7 +488,7 @@ void PS3USB::getBdaddr(uint8_t *bdaddr) {
                 bdaddr[5 - i] = buf[i + 2]; // Copy into buffer reversed, so it is LSB first
 }
 
-void PS3USB::enable_sixaxis() { // Command used to enable the Dualshock 3 and Navigation controller to send data via USB
+void PS3USB::enable_sixaxis() { // Command used to enable the Dualshock 3 and Navigation controller to send data via USBHost
         uint8_t cmd_buf[4];
         cmd_buf[0] = 0x42; // Special PS3 Controller enable commands
         cmd_buf[1] = 0x0c;

--- a/PS3USB.h
+++ b/PS3USB.h
@@ -23,7 +23,7 @@
 #include "PS3Enums.h"
 
 /* PS3 data taken from descriptors */
-#define EP_MAXPKTSIZE           64 // max size for data via USB
+#define EP_MAXPKTSIZE           64 // max size for data via USBHost
 
 /* Names we give to the 3 ps3 pipes - this is only used for setting the bluetooth address into the ps3 controllers */
 #define PS3_CONTROL_PIPE        0
@@ -40,9 +40,9 @@
 
 /**
  * This class implements support for all the official PS3 Controllers:
- * Dualshock 3, Navigation or a Motion controller via USB.
+ * Dualshock 3, Navigation or a Motion controller via USBHost.
  *
- * One can only set the color of the bulb, set the rumble, set and get the bluetooth address and calibrate the magnetometer via USB on the Move controller.
+ * One can only set the color of the bulb, set the rumble, set and get the bluetooth address and calibrate the magnetometer via USBHost on the Move controller.
  *
  * Information about the protocol can be found at the wiki: https://github.com/felis/USB_Host_Shield_2.0/wiki/PS3-Information.
  */
@@ -50,12 +50,12 @@ class PS3USB : public USBDeviceConfig {
 public:
         /**
          * Constructor for the PS3USB class.
-         * @param  pUsb   Pointer to USB class instance.
+         * @param  pUsb   Pointer to USBHost class instance.
          * @param  btadr5,btadr4,btadr3,btadr2,btadr1,btadr0
          * Pass your dongles Bluetooth address into the constructor,
          * so you are able to pair the controller with a Bluetooth dongle.
          */
-        PS3USB(USB *pUsb, uint8_t btadr5 = 0, uint8_t btadr4 = 0, uint8_t btadr3 = 0, uint8_t btadr2 = 0, uint8_t btadr1 = 0, uint8_t btadr0 = 0);
+        PS3USB(USBHost *pUsb, uint8_t btadr5 = 0, uint8_t btadr4 = 0, uint8_t btadr3 = 0, uint8_t btadr2 = 0, uint8_t btadr1 = 0, uint8_t btadr0 = 0);
 
         /** @name USBDeviceConfig implementation */
         /**
@@ -67,12 +67,12 @@ public:
          */
         uint8_t Init(uint8_t parent, uint8_t port, bool lowspeed);
         /**
-         * Release the USB device.
+         * Release the USBHost device.
          * @return 0 on success.
          */
         uint8_t Release();
         /**
-         * Poll the USB Input endpoins and run the state machines.
+         * Poll the USBHost Input endpoins and run the state machines.
          * @return 0 on success.
          */
         uint8_t Poll();
@@ -94,7 +94,7 @@ public:
         };
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.
@@ -264,8 +264,8 @@ public:
         bool PS3NavigationConnected;
 
 protected:
-        /** Pointer to USB class instance. */
-        USB *pUsb;
+        /** Pointer to USBHost class instance. */
+        USBHost *pUsb;
         /** Device address. */
         uint8_t bAddress;
         /** Endpoint info structure. */
@@ -297,7 +297,7 @@ private:
 
         /* Private commands */
         void PS3_Command(uint8_t *data, uint16_t nbytes);
-        void enable_sixaxis(); // Command used to enable the Dualshock 3 and Navigation controller to send data via USB
+        void enable_sixaxis(); // Command used to enable the Dualshock 3 and Navigation controller to send data via USBHost
         void Move_Command(uint8_t *data, uint16_t nbytes);
 };
 #endif

--- a/PS4Parser.cpp
+++ b/PS4Parser.cpp
@@ -94,7 +94,7 @@ void PS4Parser::Parse(uint8_t len, uint8_t *buf) {
 
                 if (buf[0] == 0x01) // Check report ID
                         memcpy(&ps4Data, buf + 1, min((uint8_t)(len - 1), MFK_CASTUINT8T sizeof(ps4Data)));
-                else if (buf[0] == 0x11) { // This report is send via Bluetooth, it has an offset of 2 compared to the USB data
+                else if (buf[0] == 0x11) { // This report is send via Bluetooth, it has an offset of 2 compared to the USBHost data
                         if (len < 4) {
 #ifdef DEBUG_USB_HOST
                                 Notify(PSTR("\r\nReport is too short: "), 0x80);

--- a/PS4Parser.h
+++ b/PS4Parser.h
@@ -252,8 +252,8 @@ public:
         };
 
         /**
-         * Use this to check if an USB cable is connected to the PS4 controller.
-         * @return Returns true if an USB cable is connected.
+         * Use this to check if an USBHost cable is connected to the PS4 controller.
+         * @return Returns true if an USBHost cable is connected.
          */
         bool getUsbStatus() {
                 return ps4Data.status.usb;

--- a/PS4USB.h
+++ b/PS4USB.h
@@ -26,16 +26,16 @@
 #define PS4_PID_SLIM    0x09CC // PS4 Slim Controller
 
 /**
- * This class implements support for the PS4 controller via USB.
- * It uses the HIDUniversal class for all the USB communication.
+ * This class implements support for the PS4 controller via USBHost.
+ * It uses the HIDUniversal class for all the USBHost communication.
  */
 class PS4USB : public HIDUniversal, public PS4Parser {
 public:
         /**
          * Constructor for the PS4USB class.
-         * @param  p   Pointer to the USB class instance.
+         * @param  p   Pointer to the USBHost class instance.
          */
-        PS4USB(USB *p) :
+        PS4USB(USBHost *p) :
         HIDUniversal(p) {
                 PS4Parser::Reset();
         };
@@ -59,13 +59,13 @@ public:
 protected:
         /** @name HIDUniversal implementation */
         /**
-         * Used to parse USB HID data.
+         * Used to parse USBHost HID data.
          * @param hid       Pointer to the HID class.
          * @param is_rpt_id Only used for Hubs.
          * @param len       The length of the incoming data.
          * @param buf       Pointer to the data buffer.
          */
-        virtual void ParseHIDData(USBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
+        virtual void ParseHIDData(HostUSBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
                 if (HIDUniversal::VID == PS4_VID && (HIDUniversal::PID == PS4_PID || HIDUniversal::PID == PS4_PID_SLIM))
                         PS4Parser::Parse(len, buf);
         };
@@ -115,7 +115,7 @@ protected:
 
         /** @name USBDeviceConfig implementation */
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.

--- a/PS5Parser.cpp
+++ b/PS5Parser.cpp
@@ -99,7 +99,7 @@ void PS5Parser::Parse(uint8_t len, uint8_t *buf) {
 
                 if (buf[0] == 0x01) // Check report ID
                         memcpy(&ps5Data, buf + 1, min((uint8_t)(len - 1), MFK_CASTUINT8T sizeof(ps5Data)));
-                else if (buf[0] == 0x31) { // This report is send via Bluetooth, it has an offset of 1 compared to the USB data
+                else if (buf[0] == 0x31) { // This report is send via Bluetooth, it has an offset of 1 compared to the USBHost data
                         if (len < 3) {
 #ifdef DEBUG_USB_HOST
                                 Notify(PSTR("\r\nReport is too short: "), 0x80);

--- a/PS5Parser.h
+++ b/PS5Parser.h
@@ -124,7 +124,7 @@ struct PS5Data {
         // 0x24 - 0x27 touchpad point 2
         ps5TouchpadXY xy;
 
-#if 0 // The status byte depends on if it's sent via USB or Bluetooth, so is not parsed for now
+#if 0 // The status byte depends on if it's sent via USBHost or Bluetooth, so is not parsed for now
         uint8_t reserved3; // 0x28
 
         uint8_t rightTriggerFeedback; // 0x29
@@ -268,10 +268,10 @@ public:
         };
 #endif
 
-#if 0 // These are only valid via USB, so have been commented out for now
+#if 0 // These are only valid via USBHost, so have been commented out for now
         /**
-         * Use this to check if an USB cable is connected to the PS5 controller.
-         * @return Returns true if an USB cable is connected.
+         * Use this to check if an USBHost cable is connected to the PS5 controller.
+         * @return Returns true if an USBHost cable is connected.
          */
         bool getUsbStatus() {
                 return ps5Data.status.usb;

--- a/PS5USB.h
+++ b/PS5USB.h
@@ -28,16 +28,16 @@
 #define PS5_PID         0x0CE6 // PS5 Controller
 
 /**
- * This class implements support for the PS5 controller via USB.
- * It uses the HIDUniversal class for all the USB communication.
+ * This class implements support for the PS5 controller via USBHost.
+ * It uses the HIDUniversal class for all the USBHost communication.
  */
 class PS5USB : public HIDUniversal, public PS5Parser {
 public:
         /**
          * Constructor for the PS5USB class.
-         * @param  p   Pointer to the USB class instance.
+         * @param  p   Pointer to the USBHost class instance.
          */
-        PS5USB(USB *p) :
+        PS5USB(USBHost *p) :
         HIDUniversal(p) {
                 PS5Parser::Reset();
         };
@@ -61,13 +61,13 @@ public:
 protected:
         /** @name HIDUniversal implementation */
         /**
-         * Used to parse USB HID data.
+         * Used to parse USBHost HID data.
          * @param hid       Pointer to the HID class.
          * @param is_rpt_id Only used for Hubs.
          * @param len       The length of the incoming data.
          * @param buf       Pointer to the data buffer.
          */
-        virtual void ParseHIDData(USBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
+        virtual void ParseHIDData(HostUSBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
                 if (HIDUniversal::VID == PS5_VID && HIDUniversal::PID == PS5_PID)
                         PS5Parser::Parse(len, buf);
         };
@@ -133,7 +133,7 @@ protected:
 
                 output->reportChanged = false;
 
-                // There is no need to calculate a crc32 when the controller is connected via USB
+                // There is no need to calculate a crc32 when the controller is connected via USBHost
 
                 pUsb->outTransfer(bAddress, epInfo[ hidInterfaces[0].epIndex[epInterruptOutIndex] ].epAddr, sizeof(buf), buf);
         };
@@ -141,7 +141,7 @@ protected:
 
         /** @name USBDeviceConfig implementation */
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.

--- a/PSBuzz.cpp
+++ b/PSBuzz.cpp
@@ -20,7 +20,7 @@
 // To enable serial debugging see "settings.h"
 //#define PRINTREPORT // Uncomment to print the report send by the PS Buzz Controllers
 
-void PSBuzz::ParseHIDData(USBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
+void PSBuzz::ParseHIDData(HostUSBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
         if (HIDUniversal::VID == PSBUZZ_VID && HIDUniversal::PID == PSBUZZ_PID && len > 2 && buf) {
 #ifdef PRINTREPORT
                 Notify(PSTR("\r\n"), 0x80);

--- a/PSBuzz.h
+++ b/PSBuzz.h
@@ -37,16 +37,16 @@ union PSBUZZButtons {
 } __attribute__((packed));
 
 /**
- * This class implements support for the PS Buzz controllers via USB.
- * It uses the HIDUniversal class for all the USB communication.
+ * This class implements support for the PS Buzz controllers via USBHost.
+ * It uses the HIDUniversal class for all the USBHost communication.
  */
 class PSBuzz : public HIDUniversal {
 public:
         /**
          * Constructor for the PSBuzz class.
-         * @param  p   Pointer to the USB class instance.
+         * @param  p   Pointer to the USBHost class instance.
          */
-        PSBuzz(USB *p) :
+        PSBuzz(USBHost *p) :
         HIDUniversal(p) {
                 Reset();
         };
@@ -137,13 +137,13 @@ public:
 protected:
         /** @name HIDUniversal implementation */
         /**
-         * Used to parse USB HID data.
+         * Used to parse USBHost HID data.
          * @param hid       Pointer to the HID class.
          * @param is_rpt_id Only used for Hubs.
          * @param len       The length of the incoming data.
          * @param buf       Pointer to the data buffer.
          */
-        void ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+        void ParseHIDData(HostUSBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 
         /**
          * Called when a device is successfully initialized.
@@ -164,7 +164,7 @@ protected:
 
         /** @name USBDeviceConfig implementation */
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ Currently the following boards are supported by the library:
       * GPIO6 to 11 is also **NOT** usable, as they are used to connect SPI flash chip and it is used for storing the executable binary content.
 * ESP32 is supported using the [arduino-esp32](https://github.com/espressif/arduino-esp32/)
     * GPIO5 : SS, GPIO17 : INT, GPIO18 : SCK, GPIO19 : MISO, GPIO23 : MOSI
+* ESP32-S2 is supported using the [arduino-esp32](https://github.com/espressif/arduino-esp32/)
+    * GPIO10 : SS, GPIO14 : INT, GPIO12 : SCK, GPIO13 : MISO, GPIO11 : MOSI
+* ESP32-S3 is supported using the [arduino-esp32](https://github.com/espressif/arduino-esp32/)
+    * GPIO10 : SS, GPIO14 : INT, GPIO12 : SCK, GPIO13 : MISO, GPIO11 : MOSI
+
+**Note for ESP32-S2 and ESP32-S3:** Unlike the standard ESP32, these variants require explicit SPI bus initialization in your sketch before calling Usb.Init(): SPI.begin(12, 13, 11, 10);
 
 The following boards need to be activated manually in [settings.h](settings.h):
 

--- a/SwitchProParser.cpp
+++ b/SwitchProParser.cpp
@@ -66,7 +66,7 @@ void SwitchProParser::Parse(uint8_t len, uint8_t *buf) {
                 // This driver always uses the standard full report that includes the IMU data.
                 // The downside is that it requires more processing power, as the data is send contentiously
                 // while the simple input report is only send when the button state changes however the simple
-                // input report is not available via USB and does not include the IMU data.
+                // input report is not available via USBHost and does not include the IMU data.
 
                 if (buf[0] == 0x3F) // Simple input report via Bluetooth
                         switchProOutput.enableFullReportMode = true; // Switch over to the full report
@@ -89,7 +89,7 @@ void SwitchProParser::Parse(uint8_t len, uint8_t *buf) {
                 } else if (buf[0] == 0x21) {
                         // Subcommand reply via Bluetooth
                 } else if (buf[0] == 0x81) {
-                        // Subcommand reply via USB
+                        // Subcommand reply via USBHost
                 } else {
 #ifdef DEBUG_USB_HOST
                         Notify(PSTR("\r\nUnknown report id: "), 0x80);

--- a/SwitchProParser.h
+++ b/SwitchProParser.h
@@ -358,11 +358,11 @@ protected:
          */
         virtual void sendOutputReport(uint8_t *data, uint8_t len) = 0;
 
-        /** Used to send a handshake command via USB before disabling the timeout. */
+        /** Used to send a handshake command via USBHost before disabling the timeout. */
         virtual void sendHandshake() {}
 
         /**
-         * Needed to disable USB timeout for the controller,
+         * Needed to disable USBHost timeout for the controller,
          * so it sends out data without the host having to send data continuously.
          */
         virtual void disableTimeout() {}

--- a/SwitchProUSB.h
+++ b/SwitchProUSB.h
@@ -25,16 +25,16 @@
 #define SWITCH_PRO_PID  0x2009 // Switch Pro Controller
 
 /**
- * This class implements support for the Switch Pro controller via USB.
- * It uses the HIDUniversal class for all the USB communication.
+ * This class implements support for the Switch Pro controller via USBHost.
+ * It uses the HIDUniversal class for all the USBHost communication.
  */
 class SwitchProUSB : public HIDUniversal, public SwitchProParser {
 public:
         /**
          * Constructor for the SwitchProUSB class.
-         * @param  p   Pointer to the USB class instance.
+         * @param  p   Pointer to the USBHost class instance.
          */
-        SwitchProUSB(USB *p) :
+        SwitchProUSB(USBHost *p) :
         HIDUniversal(p) {
                 SwitchProParser::Reset();
         };
@@ -58,13 +58,13 @@ public:
 protected:
         /** @name HIDUniversal implementation */
         /**
-         * Used to parse USB HID data.
+         * Used to parse USBHost HID data.
          * @param hid       Pointer to the HID class.
          * @param is_rpt_id Only used for Hubs.
          * @param len       The length of the incoming data.
          * @param buf       Pointer to the data buffer.
          */
-        virtual void ParseHIDData(USBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
+        virtual void ParseHIDData(HostUSBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
                 if (HIDUniversal::VID == SWITCH_PRO_VID && HIDUniversal::PID == SWITCH_PRO_PID)
                         SwitchProParser::Parse(len, buf);
         };
@@ -78,7 +78,7 @@ protected:
                 if (HIDUniversal::VID == SWITCH_PRO_VID && HIDUniversal::PID == SWITCH_PRO_PID) {
                         SwitchProParser::Reset();
 
-                        // We need to send a handshake and disable the timeout or the Pro controller will stop sending data via USB
+                        // We need to send a handshake and disable the timeout or the Pro controller will stop sending data via USBHost
                         // We can not send the commands quickly after each other, so we simply send out the commands at the same
                         // rate as the controller is sending data
                         switchProOutput.sendHandshake = switchProOutput.disableTimeout = true;
@@ -119,7 +119,7 @@ protected:
                 switchProOutput.sendHandshake = false;
 
                 // See: https://github.com/Dan611/hid-procon/blob/master/hid-procon.c
-                //      https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/USB-HID-Notes.md
+                //      https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/USBHost-HID-Notes.md
                 uint8_t buf[2] = { 0x80 /* PROCON_REPORT_SEND_USB */, 0x02 /* PROCON_USB_HANDSHAKE */ };
 
                 // Endpoint (control endpoint), Interface (0x00), Report Type (Output 0x02), Report ID (0x80), nbytes, data
@@ -130,7 +130,7 @@ protected:
                 switchProOutput.disableTimeout = false;
 
                 // See: https://github.com/Dan611/hid-procon/blob/master/hid-procon.c
-                //      https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/USB-HID-Notes.md
+                //      https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/USBHost-HID-Notes.md
                 uint8_t buf[2] = { 0x80 /* PROCON_REPORT_SEND_USB */, 0x04 /* PROCON_USB_ENABLE */ };
 
                 // Endpoint (control endpoint), Interface (0x00), Report Type (Output 0x02), Report ID (0x80), nbytes, data
@@ -140,7 +140,7 @@ protected:
 
         /** @name USBDeviceConfig implementation */
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.

--- a/UHS2_gpio.cpp
+++ b/UHS2_gpio.cpp
@@ -27,14 +27,14 @@ UHS2_GPIO implements "wiring" style GPIO access. Implemented by Brian Walton bri
 #include "UHS2_gpio.h"
 
 /** @brief  Implement an instance of a UHS2_GPIO object
-*   @param  pUSB Pointer to a UHS2 USB object
+*   @param  pUSB Pointer to a UHS2 USBHost object
 */
-UHS2_GPIO::UHS2_GPIO(USB *pUsb) : m_pUsb(pUsb)
+UHS2_GPIO::UHS2_GPIO(USBHost *pUsb) : m_pUsb(pUsb)
 {
 }
 
 /** @brief  Set a GPIO output value
-*   @param  pin GPIO output pin on USB Host Shield to set
+*   @param  pin GPIO output pin on USBHost Host Shield to set
 *   @param  val Value to set the pin to (zero value will clear output, non-zero value will assert output)
 */
 void UHS2_GPIO::digitalWrite(uint8_t pin, uint8_t val) {
@@ -49,7 +49,7 @@ void UHS2_GPIO::digitalWrite(uint8_t pin, uint8_t val) {
 }
 
 /** @brief  Read the value from a GPIO input pin
-*   @param  pin GPIO input pin on USB Host Shield to read
+*   @param  pin GPIO input pin on USBHost Host Shield to read
 *   @retval int Value of GPIO input (-1 on fail)
 */
 int UHS2_GPIO::digitalRead(uint8_t pin) {
@@ -61,7 +61,7 @@ int UHS2_GPIO::digitalRead(uint8_t pin) {
 }
 
 /** @brief  Read the value from a GPIO output pin
-*   @param  pin GPIO output pin on USB Host Shield to read
+*   @param  pin GPIO output pin on USBHost Host Shield to read
 *   @retval int Value of GPIO output (-1 on fail)
 *   @note   Value of MAX3421E output register, i.e. what the device has been set to, not the physical value on the pin
 */

--- a/UHS2_gpio.h
+++ b/UHS2_gpio.h
@@ -31,14 +31,14 @@ UHS2_GPIO implements "wiring" style GPIO access. Implemented by Brian Walton bri
 
 class UHS2_GPIO {
 public:
-        UHS2_GPIO(USB *pUsb);
+        UHS2_GPIO(USBHost *pUsb);
 
         void digitalWrite(uint8_t pin, uint8_t val);
         int digitalRead(uint8_t pin);
         int digitalReadOutput(uint8_t pin);
 
 private:
-        USB* m_pUsb;
+        USBHost* m_pUsb;
 };
 
 #endif // __USB2_GPIO_H__

--- a/Usb.cpp
+++ b/Usb.cpp
@@ -14,7 +14,7 @@ Circuits At Home, LTD
 Web      :  http://www.circuitsathome.com
 e-mail   :  support@circuitsathome.com
  */
-/* USB functions */
+/* USBHost functions */
 
 #include "Usb.h"
 
@@ -22,26 +22,26 @@ static uint8_t usb_error = 0;
 static uint8_t usb_task_state;
 
 /* constructor */
-USB::USB() : bmHubPre(0) {
+USBHost::USBHost() : bmHubPre(0) {
         usb_task_state = USB_DETACHED_SUBSTATE_INITIALIZE; //set up state machine
         init();
 }
 
 /* Initialize data structures */
-void USB::init() {
+void USBHost::init() {
         //devConfigIndex = 0;
         bmHubPre = 0;
 }
 
-uint8_t USB::getUsbTaskState(void) {
+uint8_t USBHost::getUsbTaskState(void) {
         return ( usb_task_state);
 }
 
-void USB::setUsbTaskState(uint8_t state) {
+void USBHost::setUsbTaskState(uint8_t state) {
         usb_task_state = state;
 }
 
-EpInfo* USB::getEpInfoEntry(uint8_t addr, uint8_t ep) {
+EpInfo* USBHost::getEpInfoEntry(uint8_t addr, uint8_t ep) {
         UsbDevice *p = addrPool.GetUsbDevicePtr(addr);
 
         if(!p || !p->epinfo)
@@ -61,7 +61,7 @@ EpInfo* USB::getEpInfoEntry(uint8_t addr, uint8_t ep) {
 /* set device table entry */
 
 /* each device is different and has different number of endpoints. This function plugs endpoint record structure, defined in application, to devtable */
-uint8_t USB::setEpInfoEntry(uint8_t addr, uint8_t epcount, EpInfo* eprecord_ptr) {
+uint8_t USBHost::setEpInfoEntry(uint8_t addr, uint8_t epcount, EpInfo* eprecord_ptr) {
         if(!eprecord_ptr)
                 return USB_ERROR_INVALID_ARGUMENT;
 
@@ -77,7 +77,7 @@ uint8_t USB::setEpInfoEntry(uint8_t addr, uint8_t epcount, EpInfo* eprecord_ptr)
         return 0;
 }
 
-uint8_t USB::SetAddress(uint8_t addr, uint8_t ep, EpInfo **ppep, uint16_t *nak_limit) {
+uint8_t USBHost::SetAddress(uint8_t addr, uint8_t ep, EpInfo **ppep, uint16_t *nak_limit) {
         UsbDevice *p = addrPool.GetUsbDevicePtr(addr);
 
         if(!p)
@@ -123,7 +123,7 @@ uint8_t USB::SetAddress(uint8_t addr, uint8_t ep, EpInfo **ppep, uint16_t *nak_l
 /* 00       =   success         */
 
 /* 01-0f    =   non-zero HRSLT  */
-uint8_t USB::ctrlReq(uint8_t addr, uint8_t ep, uint8_t bmReqType, uint8_t bRequest, uint8_t wValLo, uint8_t wValHi,
+uint8_t USBHost::ctrlReq(uint8_t addr, uint8_t ep, uint8_t bmReqType, uint8_t bRequest, uint8_t wValLo, uint8_t wValHi,
         uint16_t wInd, uint16_t total, uint16_t nbytes, uint8_t* dataptr, USBReadParser *p) {
         bool direction = false; //request direction, IN or OUT
         uint8_t rcode;
@@ -205,23 +205,23 @@ uint8_t USB::ctrlReq(uint8_t addr, uint8_t ep, uint8_t bmReqType, uint8_t bReque
 /* Keep sending INs and writes data to memory area pointed by 'data'                                                           */
 
 /* rcode 0 if no errors. rcode 01-0f is relayed from dispatchPkt(). Rcode f0 means RCVDAVIRQ error,
-            fe USB xfer timeout */
-uint8_t USB::inTransfer(uint8_t addr, uint8_t ep, uint16_t *nbytesptr, uint8_t* data, uint8_t bInterval /*= 0*/) {
+            fe USBHost xfer timeout */
+uint8_t USBHost::inTransfer(uint8_t addr, uint8_t ep, uint16_t *nbytesptr, uint8_t* data, uint8_t bInterval /*= 0*/) {
         EpInfo *pep = NULL;
         uint16_t nak_limit = 0;
 
         uint8_t rcode = SetAddress(addr, ep, &pep, &nak_limit);
 
         if(rcode) {
-                USBTRACE3("(USB::InTransfer) SetAddress Failed ", rcode, 0x81);
-                USBTRACE3("(USB::InTransfer) addr requested ", addr, 0x81);
-                USBTRACE3("(USB::InTransfer) ep requested ", ep, 0x81);
+                USBTRACE3("(USBHost::InTransfer) SetAddress Failed ", rcode, 0x81);
+                USBTRACE3("(USBHost::InTransfer) addr requested ", addr, 0x81);
+                USBTRACE3("(USBHost::InTransfer) ep requested ", ep, 0x81);
                 return rcode;
         }
         return InTransfer(pep, nak_limit, nbytesptr, data, bInterval);
 }
 
-uint8_t USB::InTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t *nbytesptr, uint8_t* data, uint8_t bInterval /*= 0*/) {
+uint8_t USBHost::InTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t *nbytesptr, uint8_t* data, uint8_t bInterval /*= 0*/) {
         uint8_t rcode = 0;
         uint8_t pktsize;
 
@@ -300,7 +300,7 @@ uint8_t USB::InTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t *nbytesptr, ui
 /* Handles NAK bug per Maxim Application Note 4000 for single buffer transfer   */
 
 /* rcode 0 if no errors. rcode 01-0f is relayed from HRSL                       */
-uint8_t USB::outTransfer(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* data) {
+uint8_t USBHost::outTransfer(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* data) {
         EpInfo *pep = NULL;
         uint16_t nak_limit = 0;
 
@@ -312,7 +312,7 @@ uint8_t USB::outTransfer(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* dat
         return OutTransfer(pep, nak_limit, nbytes, data);
 }
 
-uint8_t USB::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8_t *data) {
+uint8_t USBHost::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8_t *data) {
         uint8_t rcode = hrSUCCESS, retry_count;
         uint8_t *data_p = data; //local copy of the data pointer
         uint16_t bytes_tosend, nak_count;
@@ -397,13 +397,13 @@ breakout:
         pep->bmSndToggle = (regRd(rHRSL) & bmSNDTOGRD) ? 1 : 0; //bmSNDTOG1 : bmSNDTOG0;  //update toggle
         return ( rcode); //should be 0 in all cases
 }
-/* dispatch USB packet. Assumes peripheral address is set and relevant buffer is loaded/empty       */
+/* dispatch USBHost packet. Assumes peripheral address is set and relevant buffer is loaded/empty       */
 /* If NAK, tries to re-send up to nak_limit times                                                   */
 /* If nak_limit == 0, do not count NAKs, exit after timeout                                         */
 /* If bus timeout, re-sends up to USB_RETRY_LIMIT times                                             */
 
 /* return codes 0x00-0x0f are HRSLT( 0x00 being success ), 0xff means timeout                       */
-uint8_t USB::dispatchPkt(uint8_t token, uint8_t ep, uint16_t nak_limit) {
+uint8_t USBHost::dispatchPkt(uint8_t token, uint8_t ep, uint16_t nak_limit) {
         uint32_t timeout = (uint32_t)millis() + USB_XFER_TIMEOUT;
         uint8_t tmpdata;
         uint8_t rcode = hrSUCCESS;
@@ -456,8 +456,8 @@ uint8_t USB::dispatchPkt(uint8_t token, uint8_t ep, uint16_t nak_limit) {
         return ( rcode);
 }
 
-/* USB main task. Performs enumeration/cleanup */
-void USB::Task(void) //USB state machine
+/* USBHost main task. Performs enumeration/cleanup */
+void USBHost::Task(void) //USBHost state machine
 {
         uint8_t rcode;
         uint8_t tmpdata;
@@ -469,7 +469,7 @@ void USB::Task(void) //USB state machine
 
         tmpdata = getVbusState();
 
-        /* modify USB task state if Vbus changed */
+        /* modify USBHost task state if Vbus changed */
         switch(tmpdata) {
                 case SE1: //illegal state
                         usb_task_state = USB_DETACHED_SUBSTATE_ILLEGAL;
@@ -523,7 +523,7 @@ void USB::Task(void) //USB state machine
                                 tmpdata = regRd(rMODE) | bmSOFKAENAB; //start SOF generation
                                 regWr(rMODE, tmpdata);
                                 usb_task_state = USB_ATTACHED_SUBSTATE_WAIT_SOF;
-                                //delay = (uint32_t)millis() + 20; //20ms wait after reset per USB spec
+                                //delay = (uint32_t)millis() + 20; //20ms wait after reset per USBHost spec
                         }
                         break;
                 case USB_ATTACHED_SUBSTATE_WAIT_SOF: //todo: change check order
@@ -563,7 +563,7 @@ void USB::Task(void) //USB state machine
         } // switch( usb_task_state )
 }
 
-uint8_t USB::DefaultAddressing(uint8_t parent, uint8_t port, bool lowspeed) {
+uint8_t USBHost::DefaultAddressing(uint8_t parent, uint8_t port, bool lowspeed) {
         //uint8_t                buf[12];
         uint8_t rcode;
         UsbDevice *p0 = NULL, *p = NULL;
@@ -603,7 +603,7 @@ uint8_t USB::DefaultAddressing(uint8_t parent, uint8_t port, bool lowspeed) {
         return 0;
 };
 
-uint8_t USB::AttemptConfig(uint8_t driver, uint8_t parent, uint8_t port, bool lowspeed) {
+uint8_t USBHost::AttemptConfig(uint8_t driver, uint8_t parent, uint8_t port, bool lowspeed) {
         //printf("AttemptConfig: parent = %i, port = %i\r\n", parent, port);
         uint8_t retries = 0;
 
@@ -685,7 +685,7 @@ again:
  * 8: if we get here, no driver likes the device plugged in, so exit failure.
  *
  */
-uint8_t USB::Configuring(uint8_t parent, uint8_t port, bool lowspeed) {
+uint8_t USBHost::Configuring(uint8_t parent, uint8_t port, bool lowspeed) {
         //uint8_t bAddress = 0;
         //printf("Configuring: parent = %i, port = %i\r\n", parent, port);
         uint8_t devConfigIndex;
@@ -783,7 +783,7 @@ uint8_t USB::Configuring(uint8_t parent, uint8_t port, bool lowspeed) {
         return rcode;
 }
 
-uint8_t USB::ReleaseDevice(uint8_t addr) {
+uint8_t USBHost::ReleaseDevice(uint8_t addr) {
         if(!addr)
                 return 0;
 
@@ -798,18 +798,18 @@ uint8_t USB::ReleaseDevice(uint8_t addr) {
 #if 1 //!defined(USB_METHODS_INLINE)
 //get device descriptor
 
-uint8_t USB::getDevDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* dataptr) {
+uint8_t USBHost::getDevDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* dataptr) {
         return ( ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, 0x00, USB_DESCRIPTOR_DEVICE, 0x0000, nbytes, nbytes, dataptr, NULL));
 }
 //get configuration descriptor
 
-uint8_t USB::getConfDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t conf, uint8_t* dataptr) {
+uint8_t USBHost::getConfDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t conf, uint8_t* dataptr) {
         return ( ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, conf, USB_DESCRIPTOR_CONFIGURATION, 0x0000, nbytes, nbytes, dataptr, NULL));
 }
 
 /* Requests Configuration Descriptor. Sends two Get Conf Descr requests. The first one gets the total length of all descriptors, then the second one requests this
  total length. The length of the first request can be shorter ( 4 bytes ), however, there are devices which won't work unless this length is set to 9 */
-uint8_t USB::getConfDescr(uint8_t addr, uint8_t ep, uint8_t conf, USBReadParser *p) {
+uint8_t USBHost::getConfDescr(uint8_t addr, uint8_t ep, uint8_t conf, USBReadParser *p) {
         const uint8_t bufSize = 64;
         uint8_t buf[bufSize];
         USB_CONFIGURATION_DESCRIPTOR *ucd = reinterpret_cast<USB_CONFIGURATION_DESCRIPTOR *>(buf);
@@ -833,21 +833,21 @@ uint8_t USB::getConfDescr(uint8_t addr, uint8_t ep, uint8_t conf, USBReadParser 
 
 //get string descriptor
 
-uint8_t USB::getStrDescr(uint8_t addr, uint8_t ep, uint16_t ns, uint8_t index, uint16_t langid, uint8_t* dataptr) {
+uint8_t USBHost::getStrDescr(uint8_t addr, uint8_t ep, uint16_t ns, uint8_t index, uint16_t langid, uint8_t* dataptr) {
         return ( ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, index, USB_DESCRIPTOR_STRING, langid, ns, ns, dataptr, NULL));
 }
 //set address
 
-uint8_t USB::setAddr(uint8_t oldaddr, uint8_t ep, uint8_t newaddr) {
+uint8_t USBHost::setAddr(uint8_t oldaddr, uint8_t ep, uint8_t newaddr) {
         uint8_t rcode = ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, 0x0000, NULL, NULL);
-        //delay(2); //per USB 2.0 sect.9.2.6.3
+        //delay(2); //per USBHost 2.0 sect.9.2.6.3
         delay(300); // Older spec says you should wait at least 200ms
         return rcode;
         //return ( ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, 0x0000, NULL, NULL));
 }
 //set configuration
 
-uint8_t USB::setConf(uint8_t addr, uint8_t ep, uint8_t conf_value) {
+uint8_t USBHost::setConf(uint8_t addr, uint8_t ep, uint8_t conf_value) {
         return ( ctrlReq(addr, ep, bmREQ_SET, USB_REQUEST_SET_CONFIGURATION, conf_value, 0x00, 0x0000, 0x0000, 0x0000, NULL, NULL));
 }
 

--- a/Usb.h
+++ b/Usb.h
@@ -21,7 +21,7 @@ Circuits At Home, LTD
 Web      :  http://www.circuitsathome.com
 e-mail   :  support@circuitsathome.com
  */
-/* USB functions */
+/* USBHost functions */
 #ifndef _usb_h_
 #define _usb_h_
 

--- a/UsbCore.h
+++ b/UsbCore.h
@@ -52,6 +52,10 @@ typedef MAX3421e<P15, P5> MAX3421E; // ESP8266 boards
 typedef MAX3421e<P1, P14> MAX3421E; // M5Stack Core S3
 #elif defined(ARDUINO_XIAO_ESP32S3)
 typedef MAX3421e<P44, P4> MAX3421E; // ESP32 XIAO boards
+#elif defined(ARDUINO_ESP32S2_DEV) || defined(CONFIG_IDF_TARGET_ESP32S2)
+typedef MAX3421e<P10, P14> MAX3421E; // ESP32-S2 boards
+#elif defined(ARDUINO_ESP32S3_DEV) || defined(CONFIG_IDF_TARGET_ESP32S3)
+typedef MAX3421e<P10, P14> MAX3421E; // ESP32-S3 boards
 #elif defined(ESP32)
 typedef MAX3421e<P5, P17> MAX3421E; // ESP32 boards
 #elif defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)

--- a/UsbCore.h
+++ b/UsbCore.h
@@ -79,7 +79,7 @@ typedef MAX3421e<P10, P9> MAX3421E; // Official Arduinos (UNO, Duemilanove, Mega
 // D6-5         Type (0- standard, 1 - class, 2 - vendor, 3 - reserved)
 // D4-0         Recipient (0 - device, 1 - interface, 2 - endpoint, 3 - other, 4..31 - reserved)
 
-// USB Device Classes
+// USBHost Device Classes
 #define USB_CLASS_USE_CLASS_INFO        0x00    // Use Class Info in the Interface Descriptors
 #define USB_CLASS_AUDIO                 0x01    // Audio
 #define USB_CLASS_COM_AND_CDC_CTRL      0x02    // Communications and CDC Control
@@ -118,16 +118,16 @@ typedef MAX3421e<P10, P9> MAX3421E; // Official Arduinos (UNO, Duemilanove, Mega
 #define USB_ERROR_FailGetConfDescr                      0xE3
 #define USB_ERROR_TRANSFER_TIMEOUT                      0xFF
 
-#define USB_XFER_TIMEOUT        5000    // (5000) USB transfer timeout in milliseconds, per section 9.2.6.1 of USB 2.0 spec
+#define USB_XFER_TIMEOUT        5000    // (5000) USBHost transfer timeout in milliseconds, per section 9.2.6.1 of USBHost 2.0 spec
 //#define USB_NAK_LIMIT         32000   // NAK limit for a transfer. 0 means NAKs are not counted
 #define USB_RETRY_LIMIT         3       // 3 retry limit for a transfer
 #define USB_SETTLE_DELAY        200     // settle delay in milliseconds
 
-#define USB_NUMDEVICES          16      //number of USB devices
+#define USB_NUMDEVICES          16      //number of USBHost devices
 //#define HUB_MAX_HUBS          7       // maximum number of hubs that can be attached to the host controller
 #define HUB_PORT_RESET_DELAY    20      // hub port reset delay 10 ms recomended, can be up to 20 ms
 
-/* USB state machine states */
+/* USBHost state machine states */
 #define USB_STATE_MASK                                      0xf0
 
 #define USB_STATE_DETACHED                                  0x10
@@ -186,7 +186,7 @@ public:
 
 };
 
-/* USB Setup Packet Structure   */
+/* USBHost Setup Packet Structure   */
 typedef struct {
 
         union { // offset   description
@@ -221,13 +221,13 @@ public:
         virtual void Parse(const uint16_t len, const uint8_t *pbuf, const uint16_t &offset) = 0;
 };
 
-class USB : public MAX3421E {
+class USBHost : public MAX3421E {
         AddressPoolImpl<USB_NUMDEVICES> addrPool;
         USBDeviceConfig* devConfig[USB_NUMDEVICES];
         uint8_t bmHubPre;
 
 public:
-        USB(void);
+        USBHost(void);
 
         void SetHubPreMask() {
                 bmHubPre |= bmHUBPRE;
@@ -296,27 +296,27 @@ private:
 #if 0 //defined(USB_METHODS_INLINE)
 //get device descriptor
 
-inline uint8_t USB::getDevDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* dataptr) {
+inline uint8_t USBHost::getDevDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* dataptr) {
         return ( ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, 0x00, USB_DESCRIPTOR_DEVICE, 0x0000, nbytes, dataptr));
 }
 //get configuration descriptor
 
-inline uint8_t USB::getConfDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t conf, uint8_t* dataptr) {
+inline uint8_t USBHost::getConfDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t conf, uint8_t* dataptr) {
         return ( ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, conf, USB_DESCRIPTOR_CONFIGURATION, 0x0000, nbytes, dataptr));
 }
 //get string descriptor
 
-inline uint8_t USB::getStrDescr(uint8_t addr, uint8_t ep, uint16_t nuint8_ts, uint8_t index, uint16_t langid, uint8_t* dataptr) {
+inline uint8_t USBHost::getStrDescr(uint8_t addr, uint8_t ep, uint16_t nuint8_ts, uint8_t index, uint16_t langid, uint8_t* dataptr) {
         return ( ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, index, USB_DESCRIPTOR_STRING, langid, nuint8_ts, dataptr));
 }
 //set address
 
-inline uint8_t USB::setAddr(uint8_t oldaddr, uint8_t ep, uint8_t newaddr) {
+inline uint8_t USBHost::setAddr(uint8_t oldaddr, uint8_t ep, uint8_t newaddr) {
         return ( ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, NULL));
 }
 //set configuration
 
-inline uint8_t USB::setConf(uint8_t addr, uint8_t ep, uint8_t conf_value) {
+inline uint8_t USBHost::setConf(uint8_t addr, uint8_t ep, uint8_t conf_value) {
         return ( ctrlReq(addr, ep, bmREQ_SET, USB_REQUEST_SET_CONFIGURATION, conf_value, 0x00, 0x0000, 0x0000, NULL));
 }
 

--- a/Wii.cpp
+++ b/Wii.cpp
@@ -83,7 +83,7 @@ const uint32_t WII_PROCONTROLLER_BUTTONS[] PROGMEM = {
 };
 
 WII::WII(BTD *p, bool pair) :
-BluetoothService(p) // Pointer to USB class instance - mandatory
+BluetoothService(p) // Pointer to USBHost class instance - mandatory
 {
         pBtd->pairWithWii = pair;
 

--- a/XBOXOLD.cpp
+++ b/XBOXOLD.cpp
@@ -44,8 +44,8 @@ const uint8_t XBOXOLD_BUTTONS[] PROGMEM = {
         3, // Y
 };
 
-XBOXOLD::XBOXOLD(USB *p) :
-pUsb(p), // pointer to USB class instance - mandatory
+XBOXOLD::XBOXOLD(USBHost *p) :
+pUsb(p), // pointer to USBHost class instance - mandatory
 bAddress(0), // device address - mandatory
 bNumEP(1), // If config descriptor needs to be parsed
 qNextPollTime(0), // Reset NextPollTime
@@ -59,7 +59,7 @@ bPollEnable(false) { // don't start polling before dongle is connected
                 epInfo[i].bmNakPower = (i) ? USB_NAK_NOWAIT : USB_NAK_MAX_POWER;
         }
 
-        if(pUsb) // register in USB subsystem
+        if(pUsb) // register in USBHost subsystem
                 pUsb->RegisterDeviceClass(this); //set devConfig[] entry
 }
 
@@ -73,7 +73,7 @@ uint8_t XBOXOLD::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         uint16_t VID;
         uint8_t num_of_conf; // Number of configurations
 
-        // get memory address of USB device address pool
+        // get memory address of USBHost device address pool
         AddressPool &addrPool = pUsb->GetAddressPool();
 #ifdef EXTRADEBUG
         Notify(PSTR("\r\nXBOXUSB Init"), 0x80);

--- a/XBOXOLD.h
+++ b/XBOXOLD.h
@@ -23,7 +23,7 @@
 #include "controllerEnums.h"
 
 /* Data Xbox taken from descriptors */
-#define EP_MAXPKTSIZE       32 // Max size for data via USB
+#define EP_MAXPKTSIZE       32 // Max size for data via USBHost
 
 /* Names we give to the 3 Xbox pipes */
 #define XBOX_CONTROL_PIPE    0
@@ -44,14 +44,14 @@
 
 #define XBOX_MAX_ENDPOINTS   3
 
-/** This class implements support for a the original Xbox controller via USB. */
+/** This class implements support for a the original Xbox controller via USBHost. */
 class XBOXOLD : public USBDeviceConfig, public UsbConfigXtracter {
 public:
         /**
          * Constructor for the XBOXOLD class.
-         * @param  pUsb   Pointer to USB class instance.
+         * @param  pUsb   Pointer to USBHost class instance.
          */
-        XBOXOLD(USB *pUsb);
+        XBOXOLD(USBHost *pUsb);
 
         /** @name USBDeviceConfig implementation */
         /**
@@ -63,12 +63,12 @@ public:
          */
         uint8_t Init(uint8_t parent, uint8_t port, bool lowspeed);
         /**
-         * Release the USB device.
+         * Release the USBHost device.
          * @return 0 on success.
          */
         uint8_t Release();
         /**
-         * Poll the USB Input endpoins and run the state machines.
+         * Poll the USBHost Input endpoins and run the state machines.
          * @return 0 on success.
          */
         uint8_t Poll();
@@ -98,7 +98,7 @@ public:
         };
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.
@@ -155,8 +155,8 @@ public:
         bool XboxConnected;
 
 protected:
-        /** Pointer to USB class instance. */
-        USB *pUsb;
+        /** Pointer to USBHost class instance. */
+        USBHost *pUsb;
         /** Device address. */
         uint8_t bAddress;
         /** Endpoint info structure. */
@@ -166,7 +166,7 @@ protected:
         uint8_t bConfNum;
         /** Total number of endpoints in the configuration. */
         uint8_t bNumEP;
-        /** Next poll time based on poll interval taken from the USB descriptor. */
+        /** Next poll time based on poll interval taken from the USBHost descriptor. */
         uint32_t qNextPollTime;
 
         /** @name UsbConfigXtracter implementation */
@@ -182,8 +182,8 @@ protected:
         /**@}*/
 
         /**
-         * Used to print the USB Endpoint Descriptor.
-         * @param ep_ptr Pointer to USB Endpoint Descriptor.
+         * Used to print the USBHost Endpoint Descriptor.
+         * @param ep_ptr Pointer to USBHost Endpoint Descriptor.
          */
         void PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr);
 

--- a/XBOXONE.cpp
+++ b/XBOXONE.cpp
@@ -24,8 +24,8 @@
 //#define EXTRADEBUG // Uncomment to get even more debugging data
 //#define PRINTREPORT // Uncomment to print the report send by the Xbox ONE Controller
 
-XBOXONE::XBOXONE(USB *p) :
-pUsb(p), // pointer to USB class instance - mandatory
+XBOXONE::XBOXONE(USBHost *p) :
+pUsb(p), // pointer to USBHost class instance - mandatory
 bAddress(0), // device address - mandatory
 bNumEP(1), // If config descriptor needs to be parsed
 qNextPollTime(0), // Reset NextPollTime
@@ -39,7 +39,7 @@ bPollEnable(false) { // don't start polling before dongle is connected
                 epInfo[i].bmNakPower = (i) ? USB_NAK_NOWAIT : USB_NAK_MAX_POWER;
         }
 
-        if(pUsb) // register in USB subsystem
+        if(pUsb) // register in USBHost subsystem
                 pUsb->RegisterDeviceClass(this); //set devConfig[] entry
 }
 
@@ -52,7 +52,7 @@ uint8_t XBOXONE::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         uint16_t PID, VID;
         uint8_t num_of_conf; // Number of configurations
 
-        // get memory address of USB device address pool
+        // get memory address of USBHost device address pool
         AddressPool &addrPool = pUsb->GetAddressPool();
 #ifdef EXTRADEBUG
         Notify(PSTR("\r\nXBOXONE Init"), 0x80);

--- a/XBOXONE.h
+++ b/XBOXONE.h
@@ -27,7 +27,7 @@
 #include "xboxEnums.h"
 
 /* Xbox One data taken from descriptors */
-#define XBOX_ONE_EP_MAXPKTSIZE                  64 // Max size for data via USB
+#define XBOX_ONE_EP_MAXPKTSIZE                  64 // Max size for data via USBHost
 
 /* Names we give to the 3 XboxONE pipes */
 #define XBOX_ONE_CONTROL_PIPE                   0
@@ -63,14 +63,14 @@
 #define XBOX_ONE_PID11                          0x542A // Xbox ONE spectra
 #define XBOX_ONE_PID12                          0x543A // PowerA Xbox One wired controller
 
-/** This class implements support for a Xbox ONE controller connected via USB. */
+/** This class implements support for a Xbox ONE controller connected via USBHost. */
 class XBOXONE : public USBDeviceConfig, public UsbConfigXtracter {
 public:
         /**
          * Constructor for the XBOXONE class.
-         * @param  pUsb   Pointer to USB class instance.
+         * @param  pUsb   Pointer to USBHost class instance.
          */
-        XBOXONE(USB *pUsb);
+        XBOXONE(USBHost *pUsb);
 
         /** @name USBDeviceConfig implementation */
         /**
@@ -82,12 +82,12 @@ public:
          */
         virtual uint8_t Init(uint8_t parent, uint8_t port, bool lowspeed);
         /**
-         * Release the USB device.
+         * Release the USBHost device.
          * @return 0 on success.
          */
         virtual uint8_t Release();
         /**
-         * Poll the USB Input endpoins and run the state machines.
+         * Poll the USBHost Input endpoins and run the state machines.
          * @return 0 on success.
          */
         virtual uint8_t Poll();
@@ -117,7 +117,7 @@ public:
         };
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.
@@ -177,8 +177,8 @@ public:
         bool XboxOneConnected;
 
 protected:
-        /** Pointer to USB class instance. */
-        USB *pUsb;
+        /** Pointer to USBHost class instance. */
+        USBHost *pUsb;
         /** Device address. */
         uint8_t bAddress;
         /** Endpoint info structure. */
@@ -188,7 +188,7 @@ protected:
         uint8_t bConfNum;
         /** Total number of endpoints in the configuration. */
         uint8_t bNumEP;
-        /** Next poll time based on poll interval taken from the USB descriptor. */
+        /** Next poll time based on poll interval taken from the USBHost descriptor. */
         uint32_t qNextPollTime;
 
         /** @name UsbConfigXtracter implementation */
@@ -204,8 +204,8 @@ protected:
         /**@}*/
 
         /**
-         * Used to print the USB Endpoint Descriptor.
-         * @param ep_ptr Pointer to USB Endpoint Descriptor.
+         * Used to print the USBHost Endpoint Descriptor.
+         * @param ep_ptr Pointer to USBHost Endpoint Descriptor.
          */
         void PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr);
 

--- a/XBOXRECV.cpp
+++ b/XBOXRECV.cpp
@@ -22,8 +22,8 @@
 //#define EXTRADEBUG // Uncomment to get even more debugging data
 //#define PRINTREPORT // Uncomment to print the report send by the Xbox 360 Controller
 
-XBOXRECV::XBOXRECV(USB *p) :
-pUsb(p), // pointer to USB class instance - mandatory
+XBOXRECV::XBOXRECV(USBHost *p) :
+pUsb(p), // pointer to USBHost class instance - mandatory
 bAddress(0), // device address - mandatory
 bPollEnable(false) { // don't start polling before dongle is connected
         for(uint8_t i = 0; i < XBOX_MAX_ENDPOINTS; i++) {
@@ -34,7 +34,7 @@ bPollEnable(false) { // don't start polling before dongle is connected
                 epInfo[i].bmNakPower = (i) ? USB_NAK_NOWAIT : USB_NAK_MAX_POWER;
         }
 
-        if(pUsb) // register in USB subsystem
+        if(pUsb) // register in USBHost subsystem
                 pUsb->RegisterDeviceClass(this); //set devConfig[] entry
 }
 
@@ -47,7 +47,7 @@ uint8_t XBOXRECV::ConfigureDevice(uint8_t parent, uint8_t port, bool lowspeed) {
         EpInfo *oldep_ptr = NULL;
         uint16_t PID, VID;
 
-        AddressPool &addrPool = pUsb->GetAddressPool(); // Get memory address of USB device address pool
+        AddressPool &addrPool = pUsb->GetAddressPool(); // Get memory address of USBHost device address pool
 #ifdef EXTRADEBUG
         Notify(PSTR("\r\nXBOXRECV Init"), 0x80);
 #endif
@@ -531,7 +531,7 @@ void XBOXRECV::setLedMode(LEDModeEnum ledMode, uint8_t controller) { // This fun
 }
 
 /* PC runs this at interval of approx 2 seconds
-Thanks to BusHound from Perisoft.net for the Windows USB Analysis output
+Thanks to BusHound from Perisoft.net for the Windows USBHost Analysis output
 Found by timstamp.co.uk
  */
 void XBOXRECV::checkStatus() {

--- a/XBOXRECV.h
+++ b/XBOXRECV.h
@@ -24,7 +24,7 @@
 #include "xboxEnums.h"
 
 /* Data Xbox 360 taken from descriptors */
-#define EP_MAXPKTSIZE       32 // max size for data via USB
+#define EP_MAXPKTSIZE       32 // max size for data via USBHost
 
 /* Names we give to the 9 Xbox360 pipes */
 #define XBOX_CONTROL_PIPE   0
@@ -57,9 +57,9 @@ class XBOXRECV : public USBDeviceConfig {
 public:
         /**
          * Constructor for the XBOXRECV class.
-         * @param  pUsb   Pointer to USB class instance.
+         * @param  pUsb   Pointer to USBHost class instance.
          */
-        XBOXRECV(USB *pUsb);
+        XBOXRECV(USBHost *pUsb);
 
         /** @name USBDeviceConfig implementation */
         /**
@@ -79,12 +79,12 @@ public:
          */
         uint8_t Init(uint8_t parent, uint8_t port, bool lowspeed);
         /**
-         * Release the USB device.
+         * Release the USBHost device.
          * @return 0 on success.
          */
         uint8_t Release();
         /**
-         * Poll the USB Input endpoins and run the state machines.
+         * Poll the USBHost Input endpoins and run the state machines.
          * @return 0 on success.
          */
         uint8_t Poll();
@@ -106,7 +106,7 @@ public:
         };
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.
@@ -232,8 +232,8 @@ public:
         uint8_t Xbox360Connected[4];
 
 protected:
-        /** Pointer to USB class instance. */
-        USB *pUsb;
+        /** Pointer to USBHost class instance. */
+        USBHost *pUsb;
         /** Device address. */
         uint8_t bAddress;
         /** Endpoint info structure. */

--- a/XBOXUSB.cpp
+++ b/XBOXUSB.cpp
@@ -20,8 +20,8 @@
 //#define EXTRADEBUG // Uncomment to get even more debugging data
 //#define PRINTREPORT // Uncomment to print the report send by the Xbox 360 Controller
 
-XBOXUSB::XBOXUSB(USB *p) :
-pUsb(p), // pointer to USB class instance - mandatory
+XBOXUSB::XBOXUSB(USBHost *p) :
+pUsb(p), // pointer to USBHost class instance - mandatory
 bAddress(0), // device address - mandatory
 bPollEnable(false) { // don't start polling before dongle is connected
         for(uint8_t i = 0; i < XBOX_MAX_ENDPOINTS; i++) {
@@ -32,7 +32,7 @@ bPollEnable(false) { // don't start polling before dongle is connected
                 epInfo[i].bmNakPower = (i) ? USB_NAK_NOWAIT : USB_NAK_MAX_POWER;
         }
 
-        if(pUsb) // register in USB subsystem
+        if(pUsb) // register in USBHost subsystem
                 pUsb->RegisterDeviceClass(this); //set devConfig[] entry
 }
 
@@ -45,7 +45,7 @@ uint8_t XBOXUSB::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         uint16_t PID;
         uint16_t VID;
 
-        // get memory address of USB device address pool
+        // get memory address of USBHost device address pool
         AddressPool &addrPool = pUsb->GetAddressPool();
 #ifdef EXTRADEBUG
         Notify(PSTR("\r\nXBOXUSB Init"), 0x80);
@@ -98,12 +98,12 @@ uint8_t XBOXUSB::Init(uint8_t parent, uint8_t port, bool lowspeed) {
                 goto FailUnknownDevice;
         if(PID == XBOX_WIRELESS_PID) {
 #ifdef DEBUG_USB_HOST
-                Notify(PSTR("\r\nYou have plugged in a wireless Xbox 360 controller - it doesn't support USB communication"), 0x80);
+                Notify(PSTR("\r\nYou have plugged in a wireless Xbox 360 controller - it doesn't support USBHost communication"), 0x80);
 #endif
                 goto FailUnknownDevice;
         } else if(PID == XBOX_WIRELESS_RECEIVER_PID || PID == XBOX_WIRELESS_RECEIVER_THIRD_PARTY_PID) {
 #ifdef DEBUG_USB_HOST
-                Notify(PSTR("\r\nThis library only supports Xbox 360 controllers via USB"), 0x80);
+                Notify(PSTR("\r\nThis library only supports Xbox 360 controllers via USBHost"), 0x80);
 #endif
                 goto FailUnknownDevice;
         } else if(PID != XBOX_WIRED_PID && PID != MADCATZ_WIRED_PID && PID != GAMESTOP_WIRED_PID && PID != AFTERGLOW_WIRED_PID && PID != JOYTECH_WIRED_PID) // Check PID

--- a/XBOXUSB.h
+++ b/XBOXUSB.h
@@ -23,7 +23,7 @@
 #include "xboxEnums.h"
 
 /* Data Xbox 360 taken from descriptors */
-#define EP_MAXPKTSIZE       32 // max size for data via USB
+#define EP_MAXPKTSIZE       32 // max size for data via USBHost
 
 /* Names we give to the 3 Xbox360 pipes */
 #define XBOX_CONTROL_PIPE    0
@@ -49,14 +49,14 @@
 
 #define XBOX_MAX_ENDPOINTS   3
 
-/** This class implements support for a Xbox wired controller via USB. */
+/** This class implements support for a Xbox wired controller via USBHost. */
 class XBOXUSB : public USBDeviceConfig {
 public:
         /**
          * Constructor for the XBOXUSB class.
-         * @param  pUsb   Pointer to USB class instance.
+         * @param  pUsb   Pointer to USBHost class instance.
          */
-        XBOXUSB(USB *pUsb);
+        XBOXUSB(USBHost *pUsb);
 
         /** @name USBDeviceConfig implementation */
         /**
@@ -68,12 +68,12 @@ public:
          */
         uint8_t Init(uint8_t parent, uint8_t port, bool lowspeed);
         /**
-         * Release the USB device.
+         * Release the USBHost device.
          * @return 0 on success.
          */
         uint8_t Release();
         /**
-         * Poll the USB Input endpoins and run the state machines.
+         * Poll the USBHost Input endpoins and run the state machines.
          * @return 0 on success.
          */
         uint8_t Poll();
@@ -95,7 +95,7 @@ public:
         };
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.
@@ -185,8 +185,8 @@ public:
         bool Xbox360Connected;
 
 protected:
-        /** Pointer to USB class instance. */
-        USB *pUsb;
+        /** Pointer to USBHost class instance. */
+        USBHost *pUsb;
         /** Device address. */
         uint8_t bAddress;
         /** Endpoint info structure. */

--- a/address.h
+++ b/address.h
@@ -34,7 +34,7 @@ e-mail   :  support@circuitsathome.com
 #define USB_NAK_MAX_POWER               15              //NAK binary order maximum value
 #define USB_NAK_DEFAULT                 14              //default 32K-1 NAKs before giving up
 #define USB_NAK_NOWAIT                  1               //Single NAK stops transfer
-#define USB_NAK_NONAK                   0               //Do not count NAKs, stop retrying after USB Timeout
+#define USB_NAK_NONAK                   0               //Do not count NAKs, stop retrying after USBHost Timeout
 
 struct EpInfo {
         uint8_t epAddr; // Endpoint address

--- a/adk.cpp
+++ b/adk.cpp
@@ -22,7 +22,7 @@ e-mail   :  support@circuitsathome.com
 const uint8_t ADK::epDataInIndex = 1;
 const uint8_t ADK::epDataOutIndex = 2;
 
-ADK::ADK(USB *p, const char* manufacturer,
+ADK::ADK(USBHost *p, const char* manufacturer,
         const char* model,
         const char* description,
         const char* version,
@@ -36,7 +36,7 @@ description(description),
 version(version),
 uri(uri),
 serial(serial),
-pUsb(p), //pointer to USB class instance - mandatory
+pUsb(p), //pointer to USBHost class instance - mandatory
 bAddress(0), //device address - mandatory
 bConfNum(0), //configuration number
 bNumEP(1), //if config descriptor needs to be parsed
@@ -50,7 +50,7 @@ ready(false) {
                 epInfo[i].bmNakPower = (i) ? USB_NAK_NOWAIT : USB_NAK_MAX_POWER;
         }//for(uint8_t i=0; i<ADK_MAX_ENDPOINTS; i++...
 
-        // register in USB subsystem
+        // register in USBHost subsystem
         if(pUsb) {
                 pUsb->RegisterDeviceClass(this); //set devConfig[] entry
         }
@@ -69,7 +69,7 @@ uint8_t ADK::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         UsbDevice *p = NULL;
         EpInfo *oldep_ptr = NULL;
 
-        // get memory address of USB device address pool
+        // get memory address of USBHost device address pool
         AddressPool &addrPool = pUsb->GetAddressPool();
 
         USBTRACE("\r\nADK Init");

--- a/adk.h
+++ b/adk.h
@@ -32,7 +32,7 @@ e-mail   :  support@circuitsathome.com
 
 /* requests */
 
-#define ADK_GETPROTO      51  //check USB accessory protocol version
+#define ADK_GETPROTO      51  //check USBHost accessory protocol version
 #define ADK_SENDSTR       52  //send identifying string
 #define ADK_ACCSTART      53  //start device in accessory mode
 
@@ -70,7 +70,7 @@ protected:
         static const uint8_t epDataOutIndex; // DataOUT endpoint index
 
         /* mandatory members */
-        USB *pUsb;
+        USBHost *pUsb;
         uint8_t bAddress;
         uint8_t bConfNum; // configuration number
 
@@ -83,7 +83,7 @@ protected:
         void PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr);
 
 public:
-        ADK(USB *pUsb, const char* manufacturer,
+        ADK(USBHost *pUsb, const char* manufacturer,
                 const char* model,
                 const char* description,
                 const char* version,

--- a/avrpins.h
+++ b/avrpins.h
@@ -1926,13 +1926,93 @@ MAKE_PIN(P14, 14); // INT
   *(void * const *)(_addr); \
 })
 
-// Pinout for ESP32 dev module
+// Pinout for XIAO ESP32-S3
 
 MAKE_PIN(P8, 8); // MISO
 MAKE_PIN(P9, 9); // MOSI
 MAKE_PIN(P7, 7); // SCK
 MAKE_PIN(P44, 44); // SS
 MAKE_PIN(P4, 4); // INT
+
+#elif defined(ARDUINO_ESP32S2_DEV) || defined(CONFIG_IDF_TARGET_ESP32S2)
+
+// Workaround strict-aliasing warnings
+#ifdef pgm_read_word
+#undef pgm_read_word
+#endif
+#ifdef pgm_read_dword
+#undef pgm_read_dword
+#endif
+#ifdef  pgm_read_float
+#undef pgm_read_float
+#endif
+#ifdef  pgm_read_ptr
+#undef pgm_read_ptr
+#endif
+
+#define pgm_read_word(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const unsigned short *)(_addr); \
+})
+#define pgm_read_dword(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const unsigned long *)(_addr); \
+})
+#define pgm_read_float(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const float *)(_addr); \
+})
+#define pgm_read_ptr(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(void * const *)(_addr); \
+})
+
+// Pinout for ESP32-S2
+MAKE_PIN(P12, 12); // SCK
+MAKE_PIN(P11, 11); // MOSI
+MAKE_PIN(P13, 13); // MISO
+MAKE_PIN(P10, 10); // CS/SS
+MAKE_PIN(P14, 14); // IRQ/INT
+
+#elif defined(ARDUINO_ESP32S3_DEV) || defined(CONFIG_IDF_TARGET_ESP32S3)
+
+// Workaround strict-aliasing warnings
+#ifdef pgm_read_word
+#undef pgm_read_word
+#endif
+#ifdef pgm_read_dword
+#undef pgm_read_dword
+#endif
+#ifdef  pgm_read_float
+#undef pgm_read_float
+#endif
+#ifdef  pgm_read_ptr
+#undef pgm_read_ptr
+#endif
+
+#define pgm_read_word(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const unsigned short *)(_addr); \
+})
+#define pgm_read_dword(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const unsigned long *)(_addr); \
+})
+#define pgm_read_float(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const float *)(_addr); \
+})
+#define pgm_read_ptr(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(void * const *)(_addr); \
+})
+
+// Pinout for ESP32-S3
+MAKE_PIN(P12, 12); // SCK
+MAKE_PIN(P11, 11); // MOSI
+MAKE_PIN(P13, 13); // MISO
+MAKE_PIN(P10, 10); // CS/SS
+MAKE_PIN(P14, 14); // IRQ/INT
 
 #elif defined(ESP32)
 
@@ -1967,8 +2047,7 @@ MAKE_PIN(P4, 4); // INT
   *(void * const *)(_addr); \
 })
 
-// Pinout for ESP32 dev module
-
+// Pinout for generic ESP32 dev module
 MAKE_PIN(P0, 0);
 MAKE_PIN(P1, 1); // TX0
 MAKE_PIN(P10, 10); // TX1
@@ -1980,7 +2059,6 @@ MAKE_PIN(P23, 23); // MOSI
 MAKE_PIN(P18, 18); // SCK
 MAKE_PIN(P5, 5); // SS
 MAKE_PIN(P17, 17); // INT
-
 #endif
 
 #undef MAKE_PIN

--- a/cdc_XR21B1411.cpp
+++ b/cdc_XR21B1411.cpp
@@ -16,7 +16,7 @@ e-mail   :  support@circuitsathome.com
  */
 #include "cdc_XR21B1411.h"
 
-XR21B1411::XR21B1411(USB *p, CDCAsyncOper *pasync) :
+XR21B1411::XR21B1411(USBHost *p, CDCAsyncOper *pasync) :
 ACM(p, pasync) {
         // Is this needed??
         _enhanced_status = enhanced_features(); // Set up features

--- a/cdc_XR21B1411.h
+++ b/cdc_XR21B1411.h
@@ -104,10 +104,10 @@ class XR21B1411 : public ACM {
 protected:
 
 public:
-        XR21B1411(USB *pusb, CDCAsyncOper *pasync);
+        XR21B1411(USBHost *pusb, CDCAsyncOper *pasync);
 
         /**
-         * Used by the USB core to check what this driver support.
+         * Used by the USBHost core to check what this driver support.
          * @param  vid The device's VID.
          * @param  pid The device's PID.
          * @return     Returns true if the device's VID and PID matches this driver.

--- a/cdcacm.cpp
+++ b/cdcacm.cpp
@@ -20,7 +20,7 @@ const uint8_t ACM::epDataInIndex = 1;
 const uint8_t ACM::epDataOutIndex = 2;
 const uint8_t ACM::epInterruptInIndex = 3;
 
-ACM::ACM(USB *p, CDCAsyncOper *pasync) :
+ACM::ACM(USBHost *p, CDCAsyncOper *pasync) :
 pUsb(p),
 pAsync(pasync),
 bAddress(0),

--- a/cdcacm.h
+++ b/cdcacm.h
@@ -162,7 +162,7 @@ typedef struct {
 
 class ACM : public USBDeviceConfig, public UsbConfigXtracter {
 protected:
-        USB *pUsb;
+        USBHost *pUsb;
         CDCAsyncOper *pAsync;
         uint8_t bAddress;
         uint8_t bConfNum; // configuration number
@@ -182,7 +182,7 @@ public:
         static const uint8_t epInterruptInIndex; // InterruptIN  endpoint index
         EpInfo epInfo[ACM_MAX_ENDPOINTS];
 
-        ACM(USB *pusb, CDCAsyncOper *pasync);
+        ACM(USBHost *pusb, CDCAsyncOper *pasync);
 
         uint8_t SetCommFeature(uint16_t fid, uint8_t nbytes, uint8_t *dataptr);
         uint8_t GetCommFeature(uint16_t fid, uint8_t nbytes, uint8_t *dataptr);

--- a/cdcftdi.cpp
+++ b/cdcftdi.cpp
@@ -20,7 +20,7 @@ const uint8_t FTDI::epDataInIndex = 1;
 const uint8_t FTDI::epDataOutIndex = 2;
 const uint8_t FTDI::epInterruptInIndex = 3;
 
-FTDI::FTDI(USB *p, FTDIAsyncOper *pasync, uint16_t idProduct) :
+FTDI::FTDI(USBHost *p, FTDIAsyncOper *pasync, uint16_t idProduct) :
 pAsync(pasync),
 pUsb(p),
 bAddress(0),

--- a/cdcftdi.h
+++ b/cdcftdi.h
@@ -101,7 +101,7 @@ class FTDI : public USBDeviceConfig, public UsbConfigXtracter {
         static const uint8_t epInterruptInIndex; // InterruptIN  endpoint index
 
         FTDIAsyncOper *pAsync;
-        USB *pUsb;
+        USBHost *pUsb;
         uint8_t bAddress;
         uint8_t bConfNum; // configuration number
         uint8_t bNumIface; // number of interfaces in the configuration
@@ -117,7 +117,7 @@ class FTDI : public USBDeviceConfig, public UsbConfigXtracter {
         void PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr);
 
 public:
-        FTDI(USB *pusb, FTDIAsyncOper *pasync, uint16_t idProduct = FTDI_PID);
+        FTDI(USBHost *pusb, FTDIAsyncOper *pasync, uint16_t idProduct = FTDI_PID);
 
         uint8_t SetBaudRate(uint32_t baud);
         uint8_t SetModemControl(uint16_t control);

--- a/cdcprolific.cpp
+++ b/cdcprolific.cpp
@@ -16,7 +16,7 @@ e-mail   :  support@circuitsathome.com
  */
 #include "cdcprolific.h"
 
-PL2303::PL2303(USB *p, CDCAsyncOper *pasync) :
+PL2303::PL2303(USBHost *p, CDCAsyncOper *pasync) :
 ACM(p, pasync),
 wPLType(0) {
 }

--- a/cdcprolific.h
+++ b/cdcprolific.h
@@ -123,7 +123,7 @@ class PL2303 : public ACM {
         uint16_t wPLType; // Type of chip
 
 public:
-        PL2303(USB *pusb, CDCAsyncOper *pasync);
+        PL2303(USBHost *pusb, CDCAsyncOper *pasync);
 
         // USBDeviceConfig implementation
         uint8_t Init(uint8_t parent, uint8_t port, bool lowspeed);

--- a/controllerEnums.h
+++ b/controllerEnums.h
@@ -228,7 +228,7 @@ enum AnalogHatEnum {
 
 /**
  * Sensors inside the Sixaxis Dualshock 3, Move controller and PS4 controller.
- * <B>Note:</B> that the location is shifted 9 when it's connected via USB on the PS3 controller.
+ * <B>Note:</B> that the location is shifted 9 when it's connected via USBHost on the PS3 controller.
  */
 enum SensorEnum {
         /** Accelerometer values */

--- a/hidboot.cpp
+++ b/hidboot.cpp
@@ -16,7 +16,7 @@ e-mail   :  support@circuitsathome.com
  */
 #include "hidboot.h"
 
-void MouseReportParser::Parse(USBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len __attribute__((unused)), uint8_t *buf) {
+void MouseReportParser::Parse(HostUSBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len __attribute__((unused)), uint8_t *buf) {
         MOUSEINFO *pmi = (MOUSEINFO*)buf;
         // Future:
         // bool event;
@@ -124,7 +124,7 @@ void MouseReportParser::Parse(USBHID *hid __attribute__((unused)), bool is_rpt_i
 
 };
 
-void KeyboardReportParser::Parse(USBHID *hid, bool is_rpt_id __attribute__((unused)), uint8_t len __attribute__((unused)), uint8_t *buf) {
+void KeyboardReportParser::Parse(HostUSBHID *hid, bool is_rpt_id __attribute__((unused)), uint8_t len __attribute__((unused)), uint8_t *buf) {
         // On error - return
         if (buf[2] == 1)
                 return;

--- a/hidboot.h
+++ b/hidboot.h
@@ -56,7 +56,7 @@ class MouseReportParser : public HIDReportParser {
         } prevState;
 
 public:
-        void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+        void Parse(HostUSBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 
 protected:
 
@@ -144,11 +144,11 @@ public:
                 kbdLockingKeys.bLeds = 0;
         };
 
-        void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+        void Parse(HostUSBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 
 protected:
 
-        virtual uint8_t HandleLockingKeys(USBHID* hid, uint8_t key) {
+        virtual uint8_t HandleLockingKeys(HostUSBHID* hid, uint8_t key) {
                 uint8_t old_keys = kbdLockingKeys.bLeds;
 
                 switch(key) {
@@ -198,7 +198,7 @@ protected:
 };
 
 template <const uint8_t BOOT_PROTOCOL>
-class HIDBoot : public USBHID //public USBDeviceConfig, public UsbConfigXtracter
+class HIDBoot : public HostUSBHID //public USBDeviceConfig, public UsbConfigXtracter
 {
         EpInfo epInfo[totalEndpoints(BOOT_PROTOCOL)];
         HIDReportParser *pRptParser[epMUL(BOOT_PROTOCOL)];
@@ -219,7 +219,7 @@ class HIDBoot : public USBHID //public USBDeviceConfig, public UsbConfigXtracter
         };
 
 public:
-        HIDBoot(USB *p, bool bRptProtoEnable = false);
+        HIDBoot(USBHost *p, bool bRptProtoEnable = false);
 
         virtual bool SetReportParser(uint8_t id, HIDReportParser *prs) {
                 pRptParser[id] = prs;
@@ -253,8 +253,8 @@ public:
 };
 
 template <const uint8_t BOOT_PROTOCOL>
-HIDBoot<BOOT_PROTOCOL>::HIDBoot(USB *p, bool bRptProtoEnable/* = false*/) :
-USBHID(p),
+HIDBoot<BOOT_PROTOCOL>::HIDBoot(USBHost *p, bool bRptProtoEnable/* = false*/) :
+HostUSBHID(p),
 qNextPollTime(0),
 bPollEnable(false),
 bRptProtoEnable(bRptProtoEnable) {
@@ -362,7 +362,7 @@ uint8_t HIDBoot<BOOT_PROTOCOL>::Init(uint8_t parent, uint8_t port, bool lowspeed
                 USBTRACE2("setAddr:", rcode);
                 return rcode;
         }
-        //delay(2); //per USB 2.0 sect.9.2.6.3
+        //delay(2); //per USBHost 2.0 sect.9.2.6.3
 
         USBTRACE2("Addr:", bAddress);
 
@@ -599,7 +599,7 @@ uint8_t HIDBoot<BOOT_PROTOCOL>::Poll() {
                         // Since keyboard and mice must report at least 3 bytes, we ignore the extra data.
                         if(!rcode && read > 2) {
                                 if(pRptParser[i])
-                                        pRptParser[i]->Parse((USBHID*)this, 0, (uint8_t)read, buf);
+                                        pRptParser[i]->Parse((HostUSBHID*)this, 0, (uint8_t)read, buf);
 #ifdef DEBUG_USB_HOST
                                 // We really don't care about errors and anomalies unless we are debugging.
                         } else {

--- a/hidcomposite.cpp
+++ b/hidcomposite.cpp
@@ -17,8 +17,8 @@ e-mail   :  support@circuitsathome.com
 
 #include "hidcomposite.h"
 
-HIDComposite::HIDComposite(USB *p) :
-USBHID(p),
+HIDComposite::HIDComposite(USBHost *p) :
+HostUSBHID(p),
 qNextPollTime(0),
 pollInterval(0),
 bPollEnable(false),
@@ -166,7 +166,7 @@ uint8_t HIDComposite::Init(uint8_t parent, uint8_t port, bool lowspeed) {
                 return rcode;
         }
 
-        //delay(2); //per USB 2.0 sect.9.2.6.3
+        //delay(2); //per USBHost 2.0 sect.9.2.6.3
 
         USBTRACE2("Addr:", bAddress);
 

--- a/hidcomposite.h
+++ b/hidcomposite.h
@@ -21,7 +21,7 @@ e-mail   :  support@circuitsathome.com
 #include "usbhid.h"
 //#include "hidescriptorparser.h"
 
-class HIDComposite : public USBHID {
+class HIDComposite : public HostUSBHID {
 
 protected:
 
@@ -77,12 +77,12 @@ protected:
                 return 0;
         };
 
-        virtual void ParseHIDData(USBHID *hid __attribute__((unused)), uint8_t ep __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len __attribute__((unused)), uint8_t *buf __attribute__((unused))) {
+        virtual void ParseHIDData(HostUSBHID *hid __attribute__((unused)), uint8_t ep __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len __attribute__((unused)), uint8_t *buf __attribute__((unused))) {
                 return;
         };
 
 public:
-        HIDComposite(USB *p);
+        HIDComposite(USBHost *p);
 
         // HID implementation
         bool SetReportParser(uint8_t id, HIDReportParser *prs);

--- a/hidescriptorparser.cpp
+++ b/hidescriptorparser.cpp
@@ -1584,7 +1584,7 @@ void ReportDescParser2::OnInputItem(uint8_t itm) {
         E_Notify(PSTR("\r\n"), 0x80);
 }
 
-void UniversalReportParser::Parse(USBHID *hid, bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
+void UniversalReportParser::Parse(HostUSBHID *hid, bool is_rpt_id __attribute__((unused)), uint8_t len, uint8_t *buf) {
         ReportDescParser2 prs(len, buf);
 
         uint8_t ret = hid->GetReportDescr(0, &prs);

--- a/hidescriptorparser.h
+++ b/hidescriptorparser.h
@@ -170,7 +170,7 @@ public:
 class UniversalReportParser : public HIDReportParser {
 public:
         // Method should be defined here if virtual.
-        virtual void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
+        virtual void Parse(HostUSBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf);
 };
 
 #endif // __HIDDESCRIPTORPARSER_H__

--- a/hiduniversal.h
+++ b/hiduniversal.h
@@ -29,7 +29,7 @@ class HIDUniversal : public HIDComposite {
                 return true;
         }
 
-        void ParseHIDData(USBHID *hid, uint8_t ep __attribute__((unused)), bool is_rpt_id, uint8_t len, uint8_t *buf) final {
+        void ParseHIDData(HostUSBHID *hid, uint8_t ep __attribute__((unused)), bool is_rpt_id, uint8_t len, uint8_t *buf) final {
                 // override the HIDComposite version of this method to call the HIDUniversal version
                 // (which doesn't use the endpoint), made it final to make sure users
                 // of HIDUniversal override the right version of ParseHIDData() (the other one, below)
@@ -37,12 +37,12 @@ class HIDUniversal : public HIDComposite {
         }
 
 protected:
-        virtual void ParseHIDData(USBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len __attribute__((unused)), uint8_t *buf __attribute__((unused))) {
+        virtual void ParseHIDData(HostUSBHID *hid __attribute__((unused)), bool is_rpt_id __attribute__((unused)), uint8_t len __attribute__((unused)), uint8_t *buf __attribute__((unused))) {
                 return;
         }
 
 public:
-        HIDUniversal(USB *p) : HIDComposite(p) {}
+        HIDUniversal(USBHost *p) : HIDComposite(p) {}
 
         uint8_t Poll() override;
 

--- a/masstorage.cpp
+++ b/masstorage.cpp
@@ -226,7 +226,7 @@ again:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-BulkOnly::BulkOnly(USB *p) :
+BulkOnly::BulkOnly(USBHost *p) :
 pUsb(p),
 bAddress(0),
 bIface(0),
@@ -250,7 +250,7 @@ bLastUsbError(0) {
  * TECHNICAL: We could do most of this code elsewhere, with the exception of checking the class instance.
  * Doing so would save some program memory when using multiple drivers.
  *
- * @param parent USB address of parent
+ * @param parent USBHost address of parent
  * @param port address of port on parent
  * @param lowspeed true if device is low speed
  * @return
@@ -465,7 +465,7 @@ uint8_t BulkOnly::Init(uint8_t parent __attribute__((unused)), uint8_t port __at
                                 // try to lock media and spin up
                                 if(tries < 14) {
                                         LockMedia(lun, 1);
-                                        MediaCTL(lun, 1); // I actually have a USB stick that needs this!
+                                        MediaCTL(lun, 1); // I actually have a USBHost stick that needs this!
                                 } else delay(2 * (tries + 1));
                                 tries++;
                                 if(!tries) break;
@@ -831,7 +831,7 @@ uint8_t BulkOnly::RequestSense(uint8_t lun, uint16_t size, uint8_t *buf) {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-// USB code
+// USBHost code
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -953,7 +953,7 @@ uint8_t BulkOnly::HandleUsbError(uint8_t error, uint8_t index) {
         //ClearEpHalt(index);
         while(error && count) {
                 if(error != hrSUCCESS) {
-                        ErrorMessage<uint8_t > (PSTR("USB Error"), error);
+                        ErrorMessage<uint8_t > (PSTR("USBHost Error"), error);
                         ErrorMessage<uint8_t > (PSTR("Index"), index);
                 }
                 switch(error) {
@@ -1101,7 +1101,7 @@ uint8_t BulkOnly::Transaction(CommandBlockWrapper *pcbw, uint16_t buf_size, void
                         } else {
                                 // NOTE! Sometimes this is caused by the reported residue being wrong.
                                 // Get a different device. It isn't compliant, and should have never passed Q&A.
-                                // I own one... 05e3:0701 Genesys Logic, Inc. USB 2.0 IDE Adapter.
+                                // I own one... 05e3:0701 Genesys Logic, Inc. USBHost 2.0 IDE Adapter.
                                 // Other devices that exhibit this behavior exist in the wild too.
                                 // Be sure to check quirks in the Linux source code before reporting a bug. --xxxajk
                                 Notify(PSTR("Invalid CSW\r\n"), 0x80);

--- a/masstorage.h
+++ b/masstorage.h
@@ -40,7 +40,7 @@ e-mail   :  support@circuitsathome.com
 #define MASS_SUBCLASS_RBC               0x01
 #define MASS_SUBCLASS_ATAPI             0x02    // MMC-5 (ATAPI)
 #define MASS_SUBCLASS_OBSOLETE1         0x03    // Was QIC-157
-#define MASS_SUBCLASS_UFI               0x04    // Specifies how to interface Floppy Disk Drives to USB
+#define MASS_SUBCLASS_UFI               0x04    // Specifies how to interface Floppy Disk Drives to USBHost
 #define MASS_SUBCLASS_OBSOLETE2         0x05    // Was SFF-8070i
 #define MASS_SUBCLASS_SCSI              0x06    // SCSI Transparent Command Set
 #define MASS_SUBCLASS_LSDFS             0x07    // Specifies how host has to negotiate access before trying SCSI
@@ -154,7 +154,7 @@ e-mail   :  support@circuitsathome.com
 #define SCSI_ASC_MEDIA_CHANGED          0x28
 #define SCSI_ASC_MEDIUM_NOT_PRESENT     0x3A
 
-/* USB error codes */
+/* USBHost error codes */
 #define MASS_ERR_SUCCESS                0x00
 #define MASS_ERR_PHASE_ERROR            0x02
 #define MASS_ERR_UNIT_NOT_READY         0x03
@@ -472,7 +472,7 @@ protected:
         static const uint8_t epDataOutIndex; // DataOUT endpoint index
         static const uint8_t epInterruptInIndex; // InterruptIN  endpoint index
 
-        USB *pUsb;
+        USBHost *pUsb;
         uint8_t bAddress;
         uint8_t bConfNum; // configuration number
         uint8_t bIface; // interface value
@@ -484,7 +484,7 @@ protected:
 
         uint32_t dCBWTag; // Tag
         //uint32_t dCBWDataTransferLength; // Data Transfer Length
-        uint8_t bLastUsbError; // Last USB error
+        uint8_t bLastUsbError; // Last USBHost error
         uint8_t bMaxLUN; // Max LUN
         uint8_t bTheLUN; // Active LUN
         uint32_t CurrentCapacity[MASS_MAX_SUPPORTED_LUN]; // Total sectors
@@ -500,7 +500,7 @@ protected:
                 return 0;
         };
 public:
-        BulkOnly(USB *p);
+        BulkOnly(USBHost *p);
 
         uint8_t GetLastUsbError() {
                 return bLastUsbError;

--- a/max_LCD.cpp
+++ b/max_LCD.cpp
@@ -39,7 +39,7 @@ e-mail   :  support@circuitsathome.com
 
 static uint8_t lcdPins; //copy of LCD pins
 
-Max_LCD::Max_LCD(USB *pusb) : pUsb(pusb) {
+Max_LCD::Max_LCD(USBHost *pusb) : pUsb(pusb) {
         lcdPins = 0;
 }
 

--- a/max_LCD.h
+++ b/max_LCD.h
@@ -63,10 +63,10 @@ e-mail   :  support@circuitsathome.com
 #define LCD_5x8DOTS             0x00
 
 class Max_LCD : public Print {
-        USB *pUsb;
+        USBHost *pUsb;
 
 public:
-        Max_LCD(USB *pusb);
+        Max_LCD(USBHost *pusb);
         void init();
         void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS);
         void clear();

--- a/usb_ch9.h
+++ b/usb_ch9.h
@@ -26,10 +26,10 @@ e-mail   :  support@circuitsathome.com
 #error "Never include usb_ch9.h directly; include Usb.h instead"
 #else
 
-/* USB chapter 9 structures */
+/* USBHost chapter 9 structures */
 #define _ch9_h_
 
-/* Misc.USB constants */
+/* Misc.USBHost constants */
 #define DEV_DESCR_LEN   18      //device descriptor length
 #define CONF_DESCR_LEN  9       //configuration descriptor length
 #define INTR_DESCR_LEN  9       //interface descriptor length
@@ -65,7 +65,7 @@ e-mail   :  support@circuitsathome.com
 #define USB_SETUP_RECIPIENT_ENDPOINT            0x02    // Device Request bmRequestType recipient - endpoint
 #define USB_SETUP_RECIPIENT_OTHER               0x03    // Device Request bmRequestType recipient - other
 
-/* USB descriptors  */
+/* USBHost descriptors  */
 
 #define USB_DESCRIPTOR_DEVICE                   0x01    // bDescriptorType for a Device Descriptor.
 #define USB_DESCRIPTOR_CONFIGURATION            0x02    // bDescriptorType for a Configuration Descriptor.
@@ -86,7 +86,7 @@ e-mail   :  support@circuitsathome.com
 #define OTG_FEATURE_A_HNP_SUPPORT               4       // SET FEATURE OTG - A device supports HNP
 #define OTG_FEATURE_A_ALT_HNP_SUPPORT           5       // SET FEATURE OTG - Another port on the A device supports HNP
 
-/* USB Endpoint Transfer Types  */
+/* USBHost Endpoint Transfer Types  */
 #define USB_TRANSFER_TYPE_CONTROL               0x00    // Endpoint is a control endpoint.
 #define USB_TRANSFER_TYPE_ISOCHRONOUS           0x01    // Endpoint is an isochronous endpoint.
 #define USB_TRANSFER_TYPE_BULK                  0x02    // Endpoint is a bulk endpoint.
@@ -105,12 +105,12 @@ e-mail   :  support@circuitsathome.com
 typedef struct {
         uint8_t bLength; // Length of this descriptor.
         uint8_t bDescriptorType; // DEVICE descriptor type (USB_DESCRIPTOR_DEVICE).
-        uint16_t bcdUSB; // USB Spec Release Number (BCD).
-        uint8_t bDeviceClass; // Class code (assigned by the USB-IF). 0xFF-Vendor specific.
-        uint8_t bDeviceSubClass; // Subclass code (assigned by the USB-IF).
-        uint8_t bDeviceProtocol; // Protocol code (assigned by the USB-IF). 0xFF-Vendor specific.
+        uint16_t bcdUSB; // USBHost Spec Release Number (BCD).
+        uint8_t bDeviceClass; // Class code (assigned by the USBHost-IF). 0xFF-Vendor specific.
+        uint8_t bDeviceSubClass; // Subclass code (assigned by the USBHost-IF).
+        uint8_t bDeviceProtocol; // Protocol code (assigned by the USBHost-IF). 0xFF-Vendor specific.
         uint8_t bMaxPacketSize0; // Maximum packet size for endpoint 0.
-        uint16_t idVendor; // Vendor ID (assigned by the USB-IF).
+        uint16_t idVendor; // Vendor ID (assigned by the USBHost-IF).
         uint16_t idProduct; // Product ID (assigned by the manufacturer).
         uint16_t bcdDevice; // Device release number (BCD).
         uint8_t iManufacturer; // Index of String Descriptor describing the manufacturer.
@@ -138,9 +138,9 @@ typedef struct {
         uint8_t bInterfaceNumber; // Number of this interface (0 based).
         uint8_t bAlternateSetting; // Value of this alternate interface setting.
         uint8_t bNumEndpoints; // Number of endpoints in this interface.
-        uint8_t bInterfaceClass; // Class code (assigned by the USB-IF).  0xFF-Vendor specific.
-        uint8_t bInterfaceSubClass; // Subclass code (assigned by the USB-IF).
-        uint8_t bInterfaceProtocol; // Protocol code (assigned by the USB-IF).  0xFF-Vendor specific.
+        uint8_t bInterfaceClass; // Class code (assigned by the USBHost-IF).  0xFF-Vendor specific.
+        uint8_t bInterfaceSubClass; // Subclass code (assigned by the USBHost-IF).
+        uint8_t bInterfaceProtocol; // Protocol code (assigned by the USBHost-IF).  0xFF-Vendor specific.
         uint8_t iInterface; // Index of String Descriptor describing the interface.
 } __attribute__((packed)) USB_INTERFACE_DESCRIPTOR;
 

--- a/usbh_midi.cpp
+++ b/usbh_midi.cpp
@@ -1,12 +1,12 @@
 /*
  *******************************************************************************
- * USB-MIDI class driver for USB Host Shield 2.0 Library
+ * USBHost-MIDI class driver for USBHost Host Shield 2.0 Library
  * Copyright (c) 2012-2022 Yuuichi Akagawa
  *
- * Idea from LPK25 USB-MIDI to Serial MIDI converter
+ * Idea from LPK25 USBHost-MIDI to Serial MIDI converter
  *   by Collin Cunningham - makezine.com, narbotic.com
  *
- * for use with USB Host Shield 2.0 from Circuitsathome.com
+ * for use with USBHost Host Shield 2.0 from Circuitsathome.com
  * https://github.com/felis/USB_Host_Shield_2.0
  *******************************************************************************
  * This program is free software; you can redistribute it and/or modify
@@ -49,7 +49,7 @@
 // or
 // controlVal == (0-127)
 ///////////////////////////////////////////////////////////////////////////////
-// USB-MIDI Event Packets
+// USBHost-MIDI Event Packets
 // usb.org - Universal Serial Bus Device Class Definition for MIDI Devices 1.0
 ///////////////////////////////////////////////////////////////////////////////
 //+-------------+-------------+-------------+-------------+
@@ -82,7 +82,7 @@
 //| 0xF |     1     |Single Byte
 //+-----+-----------+-------------------------------------------------------------------
 
-USBH_MIDI::USBH_MIDI(USB *p) :
+USBH_MIDI::USBH_MIDI(USBHost *p) :
 pUsb(p),
 bAddress(0),
 bPollEnable(false),
@@ -93,7 +93,7 @@ readPtr(0) {
                 epInfo[i].maxPktSize  = (i) ? 0 : 8;
                 epInfo[i].bmNakPower  = (i) ? USB_NAK_NOWAIT : USB_NAK_MAX_POWER;
         }
-        // register in USB subsystem
+        // register in USBHost subsystem
         if (pUsb) {
                 pUsb->RegisterDeviceClass(this);
         }
@@ -124,7 +124,7 @@ uint8_t USBH_MIDI::Init(uint8_t parent, uint8_t port, bool lowspeed)
                 // epInfo[i].bmNakPower  = (i==epDataOutIndex) ? 10 : USB_NAK_NOWAIT;
         }
 
-        // get memory address of USB device address pool
+        // get memory address of USBHost device address pool
         AddressPool &addrPool = pUsb->GetAddressPool();
 
         // check if address has already been assigned to an instance
@@ -293,7 +293,7 @@ void USBH_MIDI::setupDeviceSpecific()
         // Novation
         if( vid == 0x1235 ) {
                 // LaunchPad and LaunchKey endpoint attribute is interrupt 
-                // https://github.com/YuuichiAkagawa/USBH_MIDI/wiki/Novation-USB-Product-ID-List
+                // https://github.com/YuuichiAkagawa/USBH_MIDI/wiki/Novation-USBHost-Product-ID-List
 
                 // LaunchPad: 0x20:S, 0x36:Mini, 0x51:Pro, 0x69:MK2
                 if( pid == 0x20 || pid == 0x36 || pid == 0x51 || pid == 0x69 ) {
@@ -380,7 +380,7 @@ uint8_t USBH_MIDI::SendData(uint8_t *dataptr, uint8_t nCable)
                 return SendSysEx(dataptr, countSysExDataSize(dataptr), nCable);
         }
 
-        //Building USB-MIDI Event Packets
+        //Building USBHost-MIDI Event Packets
         buf[0] = (uint8_t)(nCable << 4) | cin;
         buf[1] = dataptr[0];
 
@@ -407,7 +407,7 @@ uint8_t USBH_MIDI::SendData(uint8_t *dataptr, uint8_t nCable)
                 break;
         }
 #ifdef EXTRADEBUG
-        //Dump for raw USB-MIDI event packet
+        //Dump for raw USBHost-MIDI event packet
         Notify(PSTR("SendData():"), 0x80), D_PrintHex((buf[0]), 0x80), D_PrintHex((buf[1]), 0x80), D_PrintHex((buf[2]), 0x80), D_PrintHex((buf[3]), 0x80), Notify(PSTR("\r\n"), 0x80);
 #endif
         return pUsb->outTransfer(bAddress, epInfo[epDataOutIndex].epAddr, 4, buf);
@@ -473,7 +473,7 @@ uint8_t USBH_MIDI::SendSysEx(uint8_t *dataptr, uint16_t datasize, uint8_t nCable
         USBTRACE("SendSysEx:\r\t");
         USBTRACE2(" Length:\t", datasize);
 #ifdef EXTRADEBUG
-        uint16_t pktSize = (n+2)/3;   //Calculate total USB MIDI packet size
+        uint16_t pktSize = (n+2)/3;   //Calculate total USBHost MIDI packet size
         USBTRACE2(" Total pktSize:\t", pktSize);
 #endif
 
@@ -687,7 +687,7 @@ bool USBH_MIDI::EndpointXtract(uint8_t conf __attribute__((unused)),
 
         // Fill the rest of endpoint data structure
         epInfo[index].epAddr = (pep->bEndpointAddress & 0x0F);
-        // The maximum packet size for the USB Host Shield 2.0 library is 64 bytes.
+        // The maximum packet size for the USBHost Host Shield 2.0 library is 64 bytes.
         if(pep->wMaxPacketSize > MIDI_EVENT_PACKET_SIZE) {
                 epInfo[index].maxPktSize = MIDI_EVENT_PACKET_SIZE;
         } else {

--- a/usbh_midi.h
+++ b/usbh_midi.h
@@ -1,12 +1,12 @@
 /*
  *******************************************************************************
- * USB-MIDI class driver for USB Host Shield 2.0 Library
+ * USBHost-MIDI class driver for USBHost Host Shield 2.0 Library
  * Copyright (c) 2012-2022 Yuuichi Akagawa
  *
- * Idea from LPK25 USB-MIDI to Serial MIDI converter
+ * Idea from LPK25 USBHost-MIDI to Serial MIDI converter
  *   by Collin Cunningham - makezine.com, narbotic.com
  *
- * for use with USB Host Shield 2.0 from Circuitsathome.com
+ * for use with USBHost Host Shield 2.0 from Circuitsathome.com
  * https://github.com/felis/USB_Host_Shield_2.0
  *******************************************************************************
  * This program is free software; you can redistribute it and/or modify
@@ -84,7 +84,7 @@ protected:
         static const uint8_t    epDataOutIndex= 2;         // DataOUT endpoint index(MIDI)
 
         /* mandatory members */
-        USB      *pUsb;
+        USBHost      *pUsb;
         uint8_t  bAddress;
         bool     bPollEnable;
         uint16_t pid, vid;    // ProductID, VendorID
@@ -111,7 +111,7 @@ protected:
         void PrintEndpointDescriptor( const USB_ENDPOINT_DESCRIPTOR* ep_ptr );
 #endif
 public:
-        USBH_MIDI(USB *p);
+        USBH_MIDI(USBHost *p);
         // Misc functions
         operator bool() { return (bPollEnable); }
         uint16_t idVendor() { return vid; }

--- a/usbhid.cpp
+++ b/usbhid.cpp
@@ -20,7 +20,7 @@ e-mail   :  support@circuitsathome.com
 //get HID report descriptor
 
 /* WRONG! Endpoint is _ALWAYS_ ZERO for HID! We want the _INTERFACE_ value here!
-uint8_t USBHID::GetReportDescr(uint8_t ep, USBReadParser *parser) {
+uint8_t HostUSBHID::GetReportDescr(uint8_t ep, USBReadParser *parser) {
         const uint8_t constBufLen = 64;
         uint8_t buf[constBufLen];
 
@@ -31,7 +31,7 @@ uint8_t USBHID::GetReportDescr(uint8_t ep, USBReadParser *parser) {
         return rcode;
 }
  */
-uint8_t USBHID::GetReportDescr(uint16_t wIndex, USBReadParser *parser) {
+uint8_t HostUSBHID::GetReportDescr(uint16_t wIndex, USBReadParser *parser) {
         const uint8_t constBufLen = 64;
         uint8_t buf[constBufLen];
 
@@ -42,36 +42,36 @@ uint8_t USBHID::GetReportDescr(uint16_t wIndex, USBReadParser *parser) {
         return rcode;
 }
 
-//uint8_t USBHID::getHidDescr( uint8_t ep, uint16_t nbytes, uint8_t* dataptr )
+//uint8_t HostUSBHID::getHidDescr( uint8_t ep, uint16_t nbytes, uint8_t* dataptr )
 //{
 //    return( pUsb->ctrlReq( bAddress, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, 0x00, HID_DESCRIPTOR_HID, 0x0000, nbytes, dataptr ));
 //}
 
-uint8_t USBHID::SetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr) {
+uint8_t HostUSBHID::SetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr) {
         return ( pUsb->ctrlReq(bAddress, ep, bmREQ_HID_OUT, HID_REQUEST_SET_REPORT, report_id, report_type, iface, nbytes, nbytes, dataptr, NULL));
 }
 
-uint8_t USBHID::GetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr) {
+uint8_t HostUSBHID::GetReport(uint8_t ep, uint8_t iface, uint8_t report_type, uint8_t report_id, uint16_t nbytes, uint8_t* dataptr) {
         return ( pUsb->ctrlReq(bAddress, ep, bmREQ_HID_IN, HID_REQUEST_GET_REPORT, report_id, report_type, iface, nbytes, nbytes, dataptr, NULL));
 }
 
-uint8_t USBHID::GetIdle(uint8_t iface, uint8_t reportID, uint8_t* dataptr) {
+uint8_t HostUSBHID::GetIdle(uint8_t iface, uint8_t reportID, uint8_t* dataptr) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_HID_IN, HID_REQUEST_GET_IDLE, reportID, 0, iface, 0x0001, 0x0001, dataptr, NULL));
 }
 
-uint8_t USBHID::SetIdle(uint8_t iface, uint8_t reportID, uint8_t duration) {
+uint8_t HostUSBHID::SetIdle(uint8_t iface, uint8_t reportID, uint8_t duration) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_HID_OUT, HID_REQUEST_SET_IDLE, reportID, duration, iface, 0x0000, 0x0000, NULL, NULL));
 }
 
-uint8_t USBHID::SetProtocol(uint8_t iface, uint8_t protocol) {
+uint8_t HostUSBHID::SetProtocol(uint8_t iface, uint8_t protocol) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_HID_OUT, HID_REQUEST_SET_PROTOCOL, protocol, 0x00, iface, 0x0000, 0x0000, NULL, NULL));
 }
 
-uint8_t USBHID::GetProtocol(uint8_t iface, uint8_t* dataptr) {
+uint8_t HostUSBHID::GetProtocol(uint8_t iface, uint8_t* dataptr) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_HID_IN, HID_REQUEST_GET_PROTOCOL, 0x00, 0x00, iface, 0x0001, 0x0001, dataptr, NULL));
 }
 
-void USBHID::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr) {
+void HostUSBHID::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr) {
         Notify(PSTR("Endpoint descriptor:"), 0x80);
         Notify(PSTR("\r\nLength:\t\t"), 0x80);
         D_PrintHex<uint8_t > (ep_ptr->bLength, 0x80);
@@ -87,7 +87,7 @@ void USBHID::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr) {
         D_PrintHex<uint8_t > (ep_ptr->bInterval, 0x80);
 }
 
-void USBHID::PrintHidDescriptor(const USB_HID_DESCRIPTOR *pDesc) {
+void HostUSBHID::PrintHidDescriptor(const USB_HID_DESCRIPTOR *pDesc) {
         Notify(PSTR("\r\n\r\nHID Descriptor:\r\n"), 0x80);
         Notify(PSTR("bDescLength:\t\t"), 0x80);
         D_PrintHex<uint8_t > (pDesc->bLength, 0x80);

--- a/usbhid.h
+++ b/usbhid.h
@@ -133,16 +133,16 @@ struct MainItemIOFeature {
         uint8_t bmIsVolatileOrNonVolatile : 1;
 };
 
-class USBHID;
+class HostUSBHID;
 
 class HIDReportParser {
 public:
-        virtual void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) = 0;
+        virtual void Parse(HostUSBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) = 0;
 };
 
-class USBHID : public USBDeviceConfig, public UsbConfigXtracter {
+class HostUSBHID : public USBDeviceConfig, public UsbConfigXtracter {
 protected:
-        USB *pUsb; // USB class instance pointer
+        USBHost *pUsb; // USBHost class instance pointer
         uint8_t bAddress; // address
 
 protected:
@@ -162,10 +162,10 @@ protected:
 
 public:
 
-        USBHID(USB *pusb) : pUsb(pusb) {
+        HostUSBHID(USBHost *pusb) : pUsb(pusb) {
         };
 
-        const USB* GetUsb() {
+        const USBHost* GetUsb() {
                 return pUsb;
         };
 

--- a/usbhost.h
+++ b/usbhost.h
@@ -21,7 +21,7 @@ Circuits At Home, LTD
 Web      :  http://www.circuitsathome.com
 e-mail   :  support@circuitsathome.com
  */
-/* MAX3421E-based USB Host Library header file */
+/* MAX3421E-based USBHost Host Library header file */
 
 
 #if !defined(_usb_h_) || defined(_USBHOST_H_)
@@ -455,7 +455,7 @@ int8_t MAX3421e< SPI_SS, INTR >::Init() {
         regWr(rHIEN, bmCONDETIE | bmFRAMEIE); //connection detection
 
         /* check if device is connected */
-        regWr(rHCTL, bmSAMPLEBUS); // sample USB bus
+        regWr(rHCTL, bmSAMPLEBUS); // sample USBHost bus
         while(!(regRd(rHCTL) & bmSAMPLEBUS)); //wait for sample operation to finish
 
         busprobe(); //check if anything is connected
@@ -496,7 +496,7 @@ int8_t MAX3421e< SPI_SS, INTR >::Init(int mseconds) {
         regWr(rHIEN, bmCONDETIE | bmFRAMEIE); //connection detection
 
         /* check if device is connected */
-        regWr(rHCTL, bmSAMPLEBUS); // sample USB bus
+        regWr(rHCTL, bmSAMPLEBUS); // sample USBHost bus
         while(!(regRd(rHCTL) & bmSAMPLEBUS)); //wait for sample operation to finish
 
         busprobe(); //check if anything is connected
@@ -561,7 +561,7 @@ uint8_t MAX3421e< SPI_SS, INTR >::Task(void) {
         //    if( pinvalue == LOW ) {
         //        GpxHandler();
         //    }
-        //    usbSM();                                //USB state machine
+        //    usbSM();                                //USBHost state machine
         return ( rcode);
 }
 

--- a/usbhost.h
+++ b/usbhost.h
@@ -122,6 +122,10 @@ typedef SPi< P14, P13, P12, P15 > spi;
 typedef SPi< P36, P37, P35, P1 > spi;
 #elif defined(ARDUINO_XIAO_ESP32S3)
 typedef SPi< P7, P9, P8, P44 > spi;
+#elif defined(ARDUINO_ESP32S2_DEV) || defined(CONFIG_IDF_TARGET_ESP32S2)
+typedef SPi< P12, P11, P13, P10 > spi;
+#elif defined(ARDUINO_ESP32S3_DEV) || defined(CONFIG_IDF_TARGET_ESP32S3)
+typedef SPi< P12, P11, P13, P10 > spi;
 #elif defined(ESP32)
 typedef SPi< P18, P23, P19, P5 > spi;
 #elif defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)

--- a/usbhub.cpp
+++ b/usbhub.cpp
@@ -18,7 +18,7 @@ e-mail   :  support@circuitsathome.com
 
 bool USBHub::bResetInitiated = false;
 
-USBHub::USBHub(USB *p) :
+USBHub::USBHub(USBHost *p) :
 pUsb(p),
 bAddress(0),
 bNbrPorts(0),

--- a/usbhub.h
+++ b/usbhub.h
@@ -164,7 +164,7 @@ struct HubEvent {
 class USBHub : USBDeviceConfig {
         static bool bResetInitiated; // True when reset is triggered
 
-        USB *pUsb; // USB class instance pointer
+        USBHost *pUsb; // USBHost class instance pointer
 
         EpInfo epInfo[2]; // interrupt endpoint info structure
 
@@ -178,7 +178,7 @@ class USBHub : USBDeviceConfig {
         uint8_t PortStatusChange(uint8_t port, HubEvent &evt);
 
 public:
-        USBHub(USB *p);
+        USBHub(USBHost *p);
 
         uint8_t ClearHubFeature(uint8_t fid);
         uint8_t ClearPortFeature(uint8_t fid, uint8_t port, uint8_t sel = 0);
@@ -247,6 +247,6 @@ inline uint8_t USBHub::SetPortFeature(uint8_t fid, uint8_t port, uint8_t sel) {
         return ( pUsb->ctrlReq(bAddress, 0, bmREQ_SET_PORT_FEATURE, USB_REQUEST_SET_FEATURE, fid, 0, (((0x0000 | sel) << 8) | port), 0, 0, NULL, NULL));
 }
 
-void PrintHubPortStatus(USB *usbptr, uint8_t addr, uint8_t port, bool print_changes = false);
+void PrintHubPortStatus(USBHost *usbptr, uint8_t addr, uint8_t port, bool print_changes = false);
 
 #endif // __USBHUB_H__


### PR DESCRIPTION
This PR adds explicit support for ESP32-S2 and ESP32-S3 variants, which were previously not detected correctly because they do not define the ESP32 macro used by the generic ESP32 block.

**Changes:**
* **avrpins.h:** Added dedicated blocks for ARDUINO_ESP32S2_DEV / CONFIG_IDF_TARGET_ESP32S2 and ARDUINO_ESP32S3_DEV / CONFIG_IDF_TARGET_ESP32S3, each with the required pgm_read_* workarounds and pin definitions. Both variants share the same default SPI2 (FSPI) pins: GPIO12 (SCK), GPIO11 (MOSI), GPIO13 (MISO), GPIO10 (SS), GPIO14 (INT).
* **UsbCore.h:** Added MAX3421E typedef entries for ESP32-S2 and ESP32-S3.
* **usbhost.h:** Added SPi typedef entries for ESP32-S2 and ESP32-S3.

**Note on SPI initialization:**
Unlike the standard ESP32, the ESP32-S2 and ESP32-S3 require explicit SPI bus initialization in the sketch before calling Usb.Init(). Without this, the SPI bus will not be configured correctly and the USB host controller will fail to initialize:

`SPI.begin(12, 13, 11, 10); // SCK, MISO, MOSI, SS`

This has been tested and confirmed working on ESP32-S2.