### PR TITLE
Add support for Logic Green LGT8F328p

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Currently the following boards are supported by the library:
       * GPIO6 to 11 is also **NOT** usable, as they are used to connect SPI flash chip and it is used for storing the executable binary content.
 * ESP32 is supported using the [arduino-esp32](https://github.com/espressif/arduino-esp32/)
     * GPIO5 : SS, GPIO17 : INT, GPIO18 : SCK, GPIO19 : MISO, GPIO23 : MOSI
+* Logic Green LGT8F328p using the [LGT8fx](https://github.com/dbuezas/lgt8fx)
 
 The following boards need to be activated manually in [settings.h](settings.h):
 

--- a/usbhost.h
+++ b/usbhost.h
@@ -241,6 +241,10 @@ uint8_t* MAX3421e< SPI_SS, INTR >::bytesWr(uint8_t reg, uint8_t nbytes, uint8_t*
         HAL_SPI_Transmit(&SPI_Handle, &data, 1, HAL_MAX_DELAY);
         HAL_SPI_Transmit(&SPI_Handle, data_p, nbytes, HAL_MAX_DELAY);
         data_p += nbytes;
+#elif defined(__LGT8FX8P__)
+		USB_SPI.transfer(reg | 0x02);
+		USB_SPI.transfer(data_p, nbytes);
+		data_p += nbytes;
 #elif !defined(__AVR__) || !defined(SPDR)
 #if defined(ESP8266) || defined(ESP32)
         yield();


### PR DESCRIPTION
Added support for Logic Green LGT8F328p.

The LGT8F328p is largely a clone of the Atmega328p but with some nice enhancements.
It's specified to operate at up to 32MHz at 3.3V and is available in Nano, Uno and Pro Mini style board formats, making it ideal for the USB Host Shield. (Why does it seem entirely unknown here?)

It's an AVR and the pinout is identical to the classic Arduino's. Therefore i only had to touch the multi-byte write function to use SPI.transfer() instead of writing SPDR directly, since the SPI buffer works slightly different. (SPDR is a 4-byte register and it got an additional status register.)